### PR TITLE
build(Dockerfile): reduce image size from 2G GB to ~0.4GB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ COPY src/go.sum /tmp/signal-cli-rest-api-src/
 RUN cd /tmp/signal-cli-rest-api-src && swag init && go build
 
 # Start a fresh container for release container
-FROM openjdk:11-slim
+FROM openjdk:11-jre-slim-buster
 
 COPY --from=buildcontainer /tmp/signal-cli-rest-api-src/signal-cli-rest-api /usr/bin/signal-cli-rest-api
 COPY --from=buildcontainer /tmp/signal-cli /opt/signal-cli

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ COPY src/go.sum /tmp/signal-cli-rest-api-src/
 RUN cd /tmp/signal-cli-rest-api-src && swag init && go build
 
 # Start a fresh container for release container
-FROM openjdk:11-jre-slim-buster
+FROM adoptopenjdk:11-jre-hotspot
 
 COPY --from=buildcontainer /tmp/signal-cli-rest-api-src/signal-cli-rest-api /usr/bin/signal-cli-rest-api
 COPY --from=buildcontainer /tmp/signal-cli /opt/signal-cli


### PR DESCRIPTION
This uses mulit-stage build to separate the build phase from
the distribution image and signigicantly reduces images size.

You can find more information on Docker multistage builds here:
https://docs.docker.com/develop/develop-images/multistage-build/