### PR TITLE
Support custom "timeout" option when receiving messages

### DIFF
--- a/src/api/api.go
+++ b/src/api/api.go
@@ -491,7 +491,9 @@ func (a *Api) SendV2(c *gin.Context) {
 func (a *Api) Receive(c *gin.Context) {
 	number := c.Param("number")
 
-	command := []string{"--config", a.signalCliConfig, "-u", number, "receive", "-t", "1", "--json"}
+	timeout := c.DefaultQuery("timeout", "1")
+
+	command := []string{"--config", a.signalCliConfig, "-u", number, "receive", "-t", timeout, "--json"}
 	out, err := runSignalCli(true, command)
 	if err != nil {
 		c.JSON(400, gin.H{"error": err.Error()})


### PR DESCRIPTION
Thanks for creating this awesome project, it's made interacting with `signal-cli` so easy!

For some reason, when I query the receive endpoint, no messages are received. 
However If I pass a longer timeout of 5 seconds than I can receive messages.

I've added a `"timeout"` query param to the receive endpoint to allow for a custom timeout value.

For example:

```shell
http -v GET 'http://localhost:8080/v1/receive/+4912345678?timeout=5'
```