### PR TITLE
Run as non-root user in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,8 +41,12 @@ RUN cd /tmp/signal-cli-rest-api-src && swag init && go build
 # Start a fresh container for release container
 FROM adoptopenjdk:11-jre-hotspot
 
+RUN groupadd -g 1000 signal-api \
+	&& useradd -M -d /home -s /bin/bash -u 1000 -g 1000 signal-api
+
 COPY --from=buildcontainer /tmp/signal-cli-rest-api-src/signal-cli-rest-api /usr/bin/signal-cli-rest-api
 COPY --from=buildcontainer /tmp/signal-cli /opt/signal-cli
+COPY entrypoint.sh /entrypoint.sh
 
 RUN ln -s /opt/signal-cli/bin/signal-cli /usr/bin/signal-cli
 RUN mkdir -p /signal-cli-config/
@@ -50,4 +54,4 @@ RUN mkdir -p /home/.local/share/signal-cli
 
 EXPOSE 8080
 
-ENTRYPOINT ["signal-cli-rest-api"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,16 +41,15 @@ RUN cd /tmp/signal-cli-rest-api-src && swag init && go build
 # Start a fresh container for release container
 FROM adoptopenjdk:11-jre-hotspot
 
-RUN groupadd -g 1000 signal-api \
-	&& useradd -M -d /home -s /bin/bash -u 1000 -g 1000 signal-api
-
 COPY --from=buildcontainer /tmp/signal-cli-rest-api-src/signal-cli-rest-api /usr/bin/signal-cli-rest-api
 COPY --from=buildcontainer /tmp/signal-cli /opt/signal-cli
 COPY entrypoint.sh /entrypoint.sh
 
-RUN ln -s /opt/signal-cli/bin/signal-cli /usr/bin/signal-cli
-RUN mkdir -p /signal-cli-config/
-RUN mkdir -p /home/.local/share/signal-cli
+RUN groupadd -g 1000 signal-api \
+	&& useradd -M -d /home -s /bin/bash -u 1000 -g 1000 signal-api \
+	&& ln -s /opt/signal-cli/bin/signal-cli /usr/bin/signal-cli \
+	&& mkdir -p /signal-cli-config/ \
+	&& mkdir -p /home/.local/share/signal-cli
 
 EXPOSE 8080
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,5 +6,11 @@ set -e
 # Fix permissions to ensure backward compatibility
 chown 1000:1000 -R /home/.local/share/signal-cli
 
-# Start API
+# Show warning on docker exec
+cat <<EOF >> /root/.bashrc
+echo "WARNING: signal-cli-rest-api runs as signal-api (not as root!)" 
+echo "Run 'su signal-api' before using signal-cli!"
+EOF
+
+# Start API as signal-api user
 exec su -s /bin/sh -c "exec signal-cli-rest-api" signal-api

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -x
+set -e
+
+# Fix permissions to ensure backward compatibility
+chown 1000:1000 -R /home/.local/share/signal-cli
+
+# Start API
+exec su -s /bin/sh -c "exec signal-cli-rest-api" signal-api

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,4 +13,4 @@ echo "Run 'su signal-api' before using signal-cli!"
 EOF
 
 # Start API as signal-api user
-exec su -s /bin/sh -c "exec signal-cli-rest-api $@" signal-api
+exec setpriv --reuid=1000 --regid=1000 --init-groups --inh-caps=-all signal-cli-rest-api $@

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,4 +13,4 @@ echo "Run 'su signal-api' before using signal-cli!"
 EOF
 
 # Start API as signal-api user
-exec su -s /bin/sh -c "exec signal-cli-rest-api" signal-api
+exec su -s /bin/sh -c "exec signal-cli-rest-api $@" signal-api


### PR DESCRIPTION
Hello,

As mentioned in #31, running as non-root is a best practice.

However current users have a mount point for config with files owned by root.
This fix takes care of updating file ownership on startup.

However with this fix the binary signal-cli-rest-api runs as a child of su process.
Even if "it works", I don't know if there are hidden side effects (signal forwarding?)

Proposed roadmap:
1. Deploy this fix
2. Wait for users to move to this version (thus the owner of their config files will be updated when upgrading to this version)
3. Move back to `ENTRYPOINT ["signal-cli-rest-api"]` with `USER signal-api` directive and remove the entrypoint.sh

What is your opinion on this fix proposal?

I open the PR but please do not merge until we are sure that everything works as expected for everyone (especially current users)