### PR TITLE
JRE Dependency Fix + Port Configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ COPY src/go.sum /tmp/signal-cli-rest-api-src/
 RUN cd /tmp/signal-cli-rest-api-src && swag init && go build
 
 # Start a fresh container for release container
-FROM adoptopenjdk:11-jre-hotspot
+FROM adoptopenjdk:11-jdk-hotspot-bionic
 
 COPY --from=buildcontainer /tmp/signal-cli-rest-api-src/signal-cli-rest-api /usr/bin/signal-cli-rest-api
 COPY --from=buildcontainer /tmp/signal-cli /opt/signal-cli

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ version: "3"
 services:
   signal-cli-rest-api:
     build: "."
+    environment:
+      - PORT=8080
     ports:
       - "8080:8080" #map docker port 8080 to host port 8080.
     volumes:

--- a/src/main.go
+++ b/src/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"os"
 
 	"github.com/gin-gonic/gin"
 	log "github.com/sirupsen/logrus"
@@ -85,8 +86,17 @@ func main() {
 		}
 	}
 
-	swaggerUrl := ginSwagger.URL("http://127.0.0.1:8080/swagger/doc.json")
+	swaggerPort := getEnv("PORT", "8080")
+
+	swaggerUrl := ginSwagger.URL("http://127.0.0.1:" + string(swaggerPort) + "/swagger/doc.json")
 	router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler, swaggerUrl))
 
 	router.Run()
+}
+
+func getEnv(key string, defaultVal string) string {
+	if value, exists := os.LookupEnv(key); exists {
+		return value
+	}
+	return defaultVal
 }


### PR DESCRIPTION
Not seeing a `CONTRIBUTING.md` file so I'll do my best to be specific.

Main change: Changes the JRE image to a `Bionic`-specific image.  This change is in `Dockerfile` line 42.

This PR also allows the port to be configured through `docker-compose.yml`.  This means images built using `docker-compose` will use the configured port, but images built using `docker build` will still default to port 8080.  The environment variable definitions required to do this were added to `docker-compose.yml`.  Nothing breaks if the environment variables are omitted - the API just runs on port 8080 like it does currently.

A small change is made to `main.go` to detect the `PORT` environment variable and use it to configure Swagger if it exists, but fallback to `8080` if it does not (like if it is built with the Dockerfile).

This PR will resolve #39 and also resolve #42