### PR TITLE
group messaging fix and more verbose error message

### DIFF
--- a/src/api/api.go
+++ b/src/api/api.go
@@ -750,7 +750,7 @@ func (a *Api) GetQrCodeLink(c *gin.Context) {
 	deviceName := c.Query("device_name")
 
 	if deviceName == "" {
-		c.JSON(400, gin.H{"error": "Please provide a name for the device"})
+		c.JSON(400, gin.H{"error": "Please provide a name for the device using ../qrcodelink?device_name=<device_name> parameter"})
 		return
 	}
 

--- a/src/api/api.go
+++ b/src/api/api.go
@@ -175,13 +175,13 @@ func send(c *gin.Context, attachmentTmpDir string, signalCliConfig string, numbe
 			return
 		}
 
-		groupId, err := base64.StdEncoding.DecodeString(recipients[0])
+		_, err := base64.StdEncoding.DecodeString(recipients[0])
 		if err != nil {
 			c.JSON(400, gin.H{"error": "Invalid group id"})
 			return
 		}
 
-		cmd = append(cmd, []string{"-g", string(groupId)}...)
+		cmd = append(cmd, []string{"-g", recipients[0]}...)
 	}
 
 	attachmentTmpPaths := []string{}

--- a/src/api/api.go
+++ b/src/api/api.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"regexp"
 
 	"github.com/cyphar/filepath-securejoin"
 	"github.com/gabriel-vasile/mimetype"
@@ -165,6 +166,11 @@ func send(c *gin.Context, attachmentTmpDir string, signalCliConfig string, numbe
 	if len(recipients) == 0 {
 		c.JSON(400, gin.H{"error": "Please specify at least one recipient"})
 		return
+	}
+
+	phoneNumberRe := regexp.MustCompile(`^\+\d+$`);
+	if (! phoneNumberRe.MatchString(recipients[0])) {
+		isGroup = true;
 	}
 
 	if !isGroup {


### PR DESCRIPTION
Hello,

there are 3 commits in this pull request:

"more verbose/helpful message" → to add some more info when calling qrcodelink. "device_name" parameter is undocumented in Signal Cli REST API documentation yet mandatory.

"-g recipient/group-id needs to stay base64 encoded" → there was base64 decode string and decoded binary passed to "-g" parameter of signal-cli. I've left the check and used the original base64 id string for "-g" flag of signal-cli.

"auto detect group-id recipient" → based on examples using group-id as recipient should work out of the box, but there was/is undocumented "is_group" flag. I've added that unless recipient is a phone number then it's considered to be a group-id.

Best regards
Jozef