### PR TITLE
Add info on captcha verification to doc

### DIFF
--- a/doc/EXAMPLES.md
+++ b/doc/EXAMPLES.md
@@ -17,6 +17,16 @@ e.g:
 
 `curl -X POST -H "Content-Type: application/json" --data '{"use_voice": true}' 'http://127.0.0.1:8080/v1/register/+431212131491291'`
 
+- Register a number (with captcha)
+
+  When you try to register a number, if you receive a response like `{"error":"Captcha required for verification (null)\n"}` then Signal is requiring a captcha. To register the number you must do the following:
+  1. Go to  [https://signalcaptchas.org/registration/generate.html](https://signalcaptchas.org/registration/generate.html)
+  2. Open the developer console
+  3. Find the line that looks like this: `Prevented navigation to “signalcaptcha://{captcha value}” due to an unknown protocol.` Copy the captcha value
+  4. Use it to make the registration call like this:
+
+  `curl -X POST -H "Content-Type: application/json" -d '{"captcha":"{captcha value}"}' 'http://127.0.0.1:8080/v1/register/<number>`
+
 - Verify the number using the code received via SMS/voice
 
   `curl -X POST -H "Content-Type: application/json" 'http://127.0.0.1:8080/v1/register/<number>/verify/<verification code>'`

--- a/doc/HOMEASSISTANT.md
+++ b/doc/HOMEASSISTANT.md
@@ -57,6 +57,14 @@ e.g:
 
 `curl -X POST -H "Content-Type: application/json" 'http://127.0.0.1:8080/v1/register/+431212131491291/verify/123-456'`
 
+When you try to register a number, if you receive a response like `{"error":"Captcha required for verification (null)\n"}` then Signal is requiring a captcha. To register the number you must do the following:
+1. Go to  [https://signalcaptchas.org/registration/generate.html](https://signalcaptchas.org/registration/generate.html)
+2. Open the developer console
+3. Find the line that looks like this: `Prevented navigation to “signalcaptcha://{captcha value}” due to an unknown protocol.` Copy the captcha value
+4. Use it to make the registration call like this:
+
+`curl -X POST -H "Content-Type: application/json" -d '{"captcha":"{captcha value}"}' 'http://127.0.0.1:8080/v1/register/<number>`
+
 ## Sending messages to Signal Messenger groups
 
 The `signal-cli-rest-api` docker container is also capable of sending messages to a Signal Messenger group.

--- a/src/api/api.go
+++ b/src/api/api.go
@@ -401,6 +401,7 @@ func (a *Api) About(c *gin.Context) {
 // @Success 201
 // @Failure 400 {object} Error
 // @Param number path string true "Registered Phone Number"
+// @Param data body RegisterNumberRequest false "Additional Settings"
 // @Router /v1/register/{number} [post]
 func (a *Api) RegisterNumber(c *gin.Context) {
 	number := c.Param("number")
@@ -452,7 +453,7 @@ func (a *Api) RegisterNumber(c *gin.Context) {
 // @Success 201 {string} string "OK"
 // @Failure 400 {object} Error
 // @Param number path string true "Registered Phone Number"
-// @Param data body VerifyNumberSettings true "Additional Settings"
+// @Param data body VerifyNumberSettings false "Additional Settings"
 // @Param token path string true "Verification Code"
 // @Router /v1/register/{number}/verify/{token} [post]
 func (a *Api) VerifyRegisteredNumber(c *gin.Context) {

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -19,7 +19,6 @@ var doc = `{
         "description": "{{.Description}}",
         "title": "{{.Title}}",
         "contact": {},
-        "license": {},
         "version": "{{.Version}}"
     },
     "host": "{{.Host}}",
@@ -743,10 +742,20 @@ var doc = `{
                         "name": "number",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "description": "Additional Settings",
+                        "name": "data",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/api.RegisterNumberRequest"
+                        }
                     }
                 ],
                 "responses": {
-                    "201": {},
+                    "201": {
+                        "description": ""
+                    },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
@@ -781,7 +790,6 @@ var doc = `{
                         "description": "Additional Settings",
                         "name": "data",
                         "in": "body",
-                        "required": true,
                         "schema": {
                             "$ref": "#/definitions/api.VerifyNumberSettings"
                         }
@@ -911,7 +919,6 @@ var doc = `{
             "type": "object",
             "properties": {
                 "logging": {
-                    "type": "object",
                     "$ref": "#/definitions/api.LoggingConfiguration"
                 }
             }
@@ -995,6 +1002,17 @@ var doc = `{
             "properties": {
                 "Level": {
                     "type": "string"
+                }
+            }
+        },
+        "api.RegisterNumberRequest": {
+            "type": "object",
+            "properties": {
+                "captcha": {
+                    "type": "string"
+                },
+                "use_voice": {
+                    "type": "boolean"
                 }
             }
         },

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -4,7 +4,6 @@
         "description": "This is the Signal Cli REST API documentation.",
         "title": "Signal Cli REST API",
         "contact": {},
-        "license": {},
         "version": "1.0"
     },
     "host": "127.0.0.1:8080",
@@ -728,10 +727,20 @@
                         "name": "number",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "description": "Additional Settings",
+                        "name": "data",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/api.RegisterNumberRequest"
+                        }
                     }
                 ],
                 "responses": {
-                    "201": {},
+                    "201": {
+                        "description": ""
+                    },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
@@ -766,7 +775,6 @@
                         "description": "Additional Settings",
                         "name": "data",
                         "in": "body",
-                        "required": true,
                         "schema": {
                             "$ref": "#/definitions/api.VerifyNumberSettings"
                         }
@@ -896,7 +904,6 @@
             "type": "object",
             "properties": {
                 "logging": {
-                    "type": "object",
                     "$ref": "#/definitions/api.LoggingConfiguration"
                 }
             }
@@ -980,6 +987,17 @@
             "properties": {
                 "Level": {
                     "type": "string"
+                }
+            }
+        },
+        "api.RegisterNumberRequest": {
+            "type": "object",
+            "properties": {
+                "captcha": {
+                    "type": "string"
+                },
+                "use_voice": {
+                    "type": "boolean"
                 }
             }
         },

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -13,7 +13,6 @@ definitions:
     properties:
       logging:
         $ref: '#/definitions/api.LoggingConfiguration'
-        type: object
     type: object
   api.CreateGroup:
     properties:
@@ -68,6 +67,13 @@ definitions:
       Level:
         type: string
     type: object
+  api.RegisterNumberRequest:
+    properties:
+      captcha:
+        type: string
+      use_voice:
+        type: boolean
+    type: object
   api.SendMessageV1:
     properties:
       base64_attachment:
@@ -119,7 +125,6 @@ host: 127.0.0.1:8080
 info:
   contact: {}
   description: This is the Signal Cli REST API documentation.
-  license: {}
   title: Signal Cli REST API
   version: "1.0"
 paths:
@@ -596,10 +601,16 @@ paths:
         name: number
         required: true
         type: string
+      - description: Additional Settings
+        in: body
+        name: data
+        schema:
+          $ref: '#/definitions/api.RegisterNumberRequest'
       produces:
       - application/json
       responses:
-        "201": {}
+        "201":
+          description: ""
         "400":
           description: Bad Request
           schema:
@@ -621,7 +632,6 @@ paths:
       - description: Additional Settings
         in: body
         name: data
-        required: true
         schema:
           $ref: '#/definitions/api.VerifyNumberSettings'
       - description: Verification Code

--- a/src/go.mod
+++ b/src/go.mod
@@ -5,6 +5,8 @@ go 1.14
 require (
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
 	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
+	github.com/cyphar/filepath-securejoin v0.2.2
+	github.com/gabriel-vasile/mimetype v1.1.2
 	github.com/gin-gonic/gin v1.6.3
 	github.com/go-openapi/spec v0.19.8 // indirect
 	github.com/go-openapi/swag v0.19.9 // indirect

--- a/src/go.sum
+++ b/src/go.sum
@@ -12,8 +12,12 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSY
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng4PGlyM=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/cyphar/filepath-securejoin v0.2.2 h1:jCwT2GTP+PY5nBz3c/YL5PAIbusElVrPujOBSCj8xRg=
+github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/gabriel-vasile/mimetype v1.1.2 h1:gaPnPcNor5aZSVCJVSGipcpbgMWiAAj9z182ocSGbHU=
+github.com/gabriel-vasile/mimetype v1.1.2/go.mod h1:6CDPel/o/3/s4+bp6kIbsWATq8pmgOisOPG40CJa6To=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/gzip v0.0.1/go.mod h1:fGBJBCdt6qCZuCAOwWuFhBB4OOq9EFqlo5dEaFhhu5w=
@@ -87,6 +91,7 @@ github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJ
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=


### PR DESCRIPTION
- Added info on captcha verification to examples and home assistant doc.
- Added annotation to register number API so swagger shows info on request body
- Marked request body as not required for Verify Number API since it's optional unless asked for a PIN code

Do I have to do anything to regenerate the Swagger with the new annotations or does Swaggo run automatically? I'm not familiar with it.