### PR TITLE
Added Expiration for Contact

### DIFF
--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -1102,6 +1102,20 @@ var doc = `{
                 }
             }
         },
+        "api.UpdateContactRequest": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "number": {
+                    "type": "string"
+                },
+                "expiration": {
+                    "type": "string"
+                }
+            }
+        },
         "api.TrustIdentityRequest": {
             "type": "object",
             "properties": {

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -900,6 +900,46 @@
                     }
                 }
             }
+        },
+        "/v1/updatecontact": {
+            "post": {
+                "description": "Update Contact",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Update Contact"
+                ],
+                "summary": "Update contact expiration",
+                "parameters": [
+                    {
+                        "description": "Input Data",
+                        "name": "data",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/api.UpdateContactRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -1041,6 +1081,7 @@
                 }
             }
         },
+        
         "api.SendMessageV1": {
             "type": "object",
             "properties": {
@@ -1084,6 +1125,20 @@
                     "items": {
                         "type": "string"
                     }
+                }
+            }
+        },
+        "api.UpdateContactRequest": {
+            "type": "object",
+            "properties": {
+                "number": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "expiration": {
+                    "type": "string"
                 }
             }
         },

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -119,6 +119,15 @@ definitions:
           type: string
         type: array
     type: object
+  api.UpdateContactRequest:
+    properties:
+      number:
+        type: string
+      name:
+        type: string
+      expiration:
+        type: string
+    type: object
   api.TrustIdentityRequest:
     properties:
       verified_safety_number:

--- a/src/main.go
+++ b/src/main.go
@@ -139,6 +139,11 @@ func main() {
 			identities.GET(":number", api.ListIdentities)
 			identities.PUT(":number/trust/:numbertotrust", api.TrustIdentity)
 		}
+
+		contacts := v1.Group("updatecontact")
+		{
+			contacts.POST("", api.UpdateContact)
+		}
 	}
 
 	v2 := router.Group("/v2")


### PR DESCRIPTION
Added Expiration for Contact to Signal CLI.  I haven't much of a clue of how .go works so you might need to re-run the swagger to pull the doc interface.  its listed under v1 update contact and the API appears to work.  User must set the expiration prior to sending a message as previous messages aren't linked to the new timeout.