### PR TITLE
Added support for missing send arguments

### DIFF
--- a/src/api/api.go
+++ b/src/api/api.go
@@ -97,6 +97,11 @@ type SendMessageV2 struct {
 	Recipients        []string `json:"recipients"`
 	Message           string   `json:"message"`
 	Base64Attachments []string `json:"base64_attachments" example:"<BASE64 ENCODED DATA>,data:<MIME-TYPE>;base64<comma><BASE64 ENCODED DATA>,data:<MIME-TYPE>;filename=<FILENAME>;base64<comma><BASE64 ENCODED DATA>"`
+	Mentions          []string `json:"mentions"`
+	QuoteTimestamp    *int64  `json:"quote_timestamp"`
+	QuoteAuthor       *string  `json:"quote_author"`
+	QuoteMessage      *string  `json:"quote_message"`
+	QuoteMentions     []string `json:"quote_mentions"`
 }
 
 type TypingIndicatorRequest struct {
@@ -354,7 +359,8 @@ func (a *Api) SendV2(c *gin.Context) {
 		return
 	}
 
-	timestamps, err := a.signalClient.SendV2(req.Number, req.Message, req.Recipients, req.Base64Attachments)
+	timestamps, err := a.signalClient.SendV2(req.Number, req.Message, req.Recipients, req.Base64Attachments,
+		req.Mentions, req.QuoteTimestamp, req.QuoteAuthor, req.QuoteMessage, req.QuoteMentions)
 	if err != nil {
 		c.JSON(400, Error{Msg: err.Error()})
 		return

--- a/src/api/api.go
+++ b/src/api/api.go
@@ -93,15 +93,15 @@ type SendMessageV1 struct {
 }
 
 type SendMessageV2 struct {
-	Number            string   `json:"number"`
-	Recipients        []string `json:"recipients"`
-	Message           string   `json:"message"`
-	Base64Attachments []string `json:"base64_attachments" example:"<BASE64 ENCODED DATA>,data:<MIME-TYPE>;base64<comma><BASE64 ENCODED DATA>,data:<MIME-TYPE>;filename=<FILENAME>;base64<comma><BASE64 ENCODED DATA>"`
-	Mentions          []string `json:"mentions"`
-	QuoteTimestamp    *int64  `json:"quote_timestamp"`
-	QuoteAuthor       *string  `json:"quote_author"`
-	QuoteMessage      *string  `json:"quote_message"`
-	QuoteMentions     []string `json:"quote_mentions"`
+	Number            string                    `json:"number"`
+	Recipients        []string                  `json:"recipients"`
+	Message           string                    `json:"message"`
+	Base64Attachments []string                  `json:"base64_attachments" example:"<BASE64 ENCODED DATA>,data:<MIME-TYPE>;base64<comma><BASE64 ENCODED DATA>,data:<MIME-TYPE>;filename=<FILENAME>;base64<comma><BASE64 ENCODED DATA>"`
+	Mentions          []client.MessageMention   `json:"mentions"`
+	QuoteTimestamp    *int64                    `json:"quote_timestamp"`
+	QuoteAuthor       *string                   `json:"quote_author"`
+	QuoteMessage      *string                   `json:"quote_message"`
+	QuoteMentions     []client.MessageMention   `json:"quote_mentions"`
 }
 
 type TypingIndicatorRequest struct {

--- a/src/client/client.go
+++ b/src/client/client.go
@@ -295,7 +295,7 @@ func (s *MessageMention) toString() string {
 
 func (s *SignalClient) send(number string, message string,
 	recipients []string, base64Attachments []string, isGroup bool, mentions []MessageMention,
-	quote_timestamp *int64, quote_author *string, quote_message *string, quote_mentions []MessageMention) (*SendResponse, error) {
+	quoteTimestamp *int64, quoteAuthor *string, quoteMessage *string, quoteMentions []MessageMention) (*SendResponse, error) {
 
 	var resp SendResponse
 
@@ -364,12 +364,12 @@ func (s *SignalClient) send(number string, message string,
 		} else {
 		    request.Mentions = nil
 		}
-		request.QuoteTimestamp = quote_timestamp
-		request.QuoteAuthor = quote_author
-		request.QuoteMessage = quote_message
-		if quote_mentions != nil {
-		    request.QuoteMentions = make([]string, len(quote_mentions))
-		    for i, mention := range quote_mentions {
+		request.QuoteTimestamp = quoteTimestamp
+		request.QuoteAuthor = quoteAuthor
+		request.QuoteMessage = quoteMessage
+		if quoteMentions != nil {
+		    request.QuoteMentions = make([]string, len(quoteMentions))
+		    for i, mention := range quoteMentions {
 		        request.QuoteMentions[i] = mention.toString()
 		    }
 		} else {
@@ -409,22 +409,22 @@ func (s *SignalClient) send(number string, message string,
 			cmd = append(cmd, mention.toString())
 		}
 
-		if quote_timestamp != nil {
+		if quoteTimestamp != nil {
 			cmd = append(cmd, "--quote-timestamp")
-			cmd = append(cmd, strconv.FormatInt(*quote_timestamp, 10))
+			cmd = append(cmd, strconv.FormatInt(*quoteTimestamp, 10))
 		}
 
-		if quote_author != nil {
+		if quoteAuthor != nil {
 			cmd = append(cmd, "--quote-author")
-			cmd = append(cmd, *quote_author)
+			cmd = append(cmd, *quoteAuthor)
 		}
 
-		if quote_message != nil {
+		if quoteMessage != nil {
 			cmd = append(cmd, "--quote-message")
-			cmd = append(cmd, *quote_message)
+			cmd = append(cmd, *quoteMessage)
 		}
 
-		for _, mention := range quote_mentions {
+		for _, mention := range quoteMentions {
 			cmd = append(cmd, "--quote-mention")
 			cmd = append(cmd, mention.toString())
 		}
@@ -539,7 +539,7 @@ func (s *SignalClient) getJsonRpc2Clients() []*JsonRpc2Client {
 }
 
 func (s *SignalClient) SendV2(number string, message string, recps []string, base64Attachments []string, mentions []MessageMention,
-	quote_timestamp *int64, quote_author *string, quote_message *string, quote_mentions []MessageMention) (*[]SendResponse, error) {
+	quoteTimestamp *int64, quoteAuthor *string, quoteMessage *string, quoteMentions []MessageMention) (*[]SendResponse, error) {
 	if len(recps) == 0 {
 		return nil, errors.New("Please provide at least one recipient")
 	}
@@ -569,7 +569,7 @@ func (s *SignalClient) SendV2(number string, message string, recps []string, bas
 
 	timestamps := []SendResponse{}
 	for _, group := range groups {
-		timestamp, err := s.send(number, message, []string{group}, base64Attachments, true, mentions, quote_timestamp, quote_author, quote_message, quote_mentions)
+		timestamp, err := s.send(number, message, []string{group}, base64Attachments, true, mentions, quoteTimestamp, quoteAuthor, quoteMessage, quoteMentions)
 		if err != nil {
 			return nil, err
 		}
@@ -577,7 +577,7 @@ func (s *SignalClient) SendV2(number string, message string, recps []string, bas
 	}
 
 	if len(recipients) > 0 {
-		timestamp, err := s.send(number, message, recipients, base64Attachments, false, mentions, quote_timestamp, quote_author, quote_message, quote_mentions)
+		timestamp, err := s.send(number, message, recipients, base64Attachments, false, mentions, quoteTimestamp, quoteAuthor, quoteMessage, quoteMentions)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Added support for missing send arguments:
- Mentions
- Quote timestamp
- Quote author
- Quote message
- Quote mentions

This is tested locally with `normal` and `json-rpc`.

~I'm not sure if a `v3` is required. If you think not, I can merge it back to `v2`.~ Edit: it is, otherwise clients have no way to know if mentions and quotes are supported or not (and would simply be lost)

WARNING: this my first ever experience w/ Go, please pay extra attention while reviewing.