### PR TITLE
fix: include $stdin in server response on error

### DIFF
--- a/src/client/cli.go
+++ b/src/client/cli.go
@@ -83,10 +83,9 @@ func (s *CliClient) Execute(wait bool, args []string, stdin string) (string, err
 		cmd.Stdin = strings.NewReader(stdin)
 	}
 	if wait {
-		var errBuffer bytes.Buffer
-		var outBuffer bytes.Buffer
-		cmd.Stderr = &errBuffer
-		cmd.Stdout = &outBuffer
+		var combinedOutput bytes.Buffer
+		cmd.Stdout = &combinedOutput
+		cmd.Stderr = &combinedOutput
 
 		err := cmd.Start()
 		if err != nil {
@@ -106,11 +105,11 @@ func (s *CliClient) Execute(wait bool, args []string, stdin string) (string, err
 			return "", errors.New("process killed as timeout reached")
 		case err := <-done:
 			if err != nil {
-				return "", errors.New(errBuffer.String())
+				return "", errors.New(combinedOutput.String())
 			}
 		}
 
-		return outBuffer.String(), nil
+		return combinedOutput.String(), nil
 	} else {
 		stdout, err := cmd.StdoutPipe()
 		if err != nil {


### PR DESCRIPTION
Motivation
----------
The way how I fixed this is that both `Stdout` and `Stderr` are responded back to the client (always).

I don't think it's good practice to discard `$stderr` on success and to discard `$stdout` on error.

Let me know what you think. I'm still very new to Golang.

How to test
-----------
1. First of all you must be able to reproduce "CAPTCHA proof required" error (I guess you need to send a lot of messages to the same number)
2. Execute:
```
curl -X POST -H "Content-Type: application/json" 'http://localhost:8080/v2/send' \
       -d '{"message": "Test via Signal API!", "number": "<SENDER_PHONE_NUMBER>", "recipients": [ "<RECIPIENT_PHONE_NUMBER>" ]}
'
```
3. See in the JSON response:
```
{"error":"Failed to send (some) messages:\n+49176xxxxxxxx: CAPTCHA proof required for sending to \"+49176xxxxxxxx\", available options \"RECAPTCHA, PUSH_CHALLENGE\" with challenge token \"1f209ee0-d487-4efc-xxxx-xxxxxxxxxxxx\", or wait \"86400\" seconds.\nTo get the captcha token, go to https://signalcaptchas.org/challenge/generate.html\nCheck the developer tools (F12) console for a failed redirect to signalcaptcha://\nEverything after signalcaptcha:// is the captcha token.\nUse the following command to submit the captcha token:\nsignal-cli submitRateLimitChallenge --challenge CHALLENGE_TOKEN --captcha CAPTCHA_TOKEN\nxxxxxxxxxxxxx\nFailed to send message\n"}
```

fix #403
