### PR TITLE
Add the ability to refresh a group.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 signal-cli-config
 src/main
 src/signal-cli-rest-api
+.idea/

--- a/src/api/api.go
+++ b/src/api/api.go
@@ -1229,17 +1229,17 @@ func (a *Api) QuitGroup(c *gin.Context) {
 	c.Status(http.StatusNoContent)
 }
 
-// @Summary Refresh the state of a Signal Group.
+// @Summary Update the state of a Signal Group.
 // @Tags Groups
-// @Description Refresh the state of a Signal Group.
+// @Description Update the state of a Signal Group.
 // @Accept  json
 // @Produce  json
 // @Success 204 {string} OK
 // @Failure 400 {object} Error
 // @Param number path string true "Registered Phone Number"
 // @Param groupid path string true "Group ID"
-// @Router /v1/groups/{number}/{groupid}/refresh [post]
-func (a *Api) RefreshGroup(c *gin.Context) {
+// @Router /v1/groups/{number}/{groupid} [put]
+func (a *Api) UpdateGroup(c *gin.Context) {
 	number := c.Param("number")
 	if number == "" {
 		c.JSON(400, Error{Msg: "Couldn't process request - number missing"})
@@ -1253,7 +1253,7 @@ func (a *Api) RefreshGroup(c *gin.Context) {
 		return
 	}
 
-	err = a.signalClient.RefreshGroup(number, internalGroupId)
+	err = a.signalClient.UpdateGroup(number, internalGroupId)
 	if err != nil {
 		c.JSON(400, Error{Msg: err.Error()})
 		return

--- a/src/api/api.go
+++ b/src/api/api.go
@@ -1229,6 +1229,38 @@ func (a *Api) QuitGroup(c *gin.Context) {
 	c.Status(http.StatusNoContent)
 }
 
+// @Summary Refresh the state of a Signal Group.
+// @Tags Groups
+// @Description Refresh the state of a Signal Group.
+// @Accept  json
+// @Produce  json
+// @Success 204 {string} OK
+// @Failure 400 {object} Error
+// @Param number path string true "Registered Phone Number"
+// @Param groupid path string true "Group ID"
+// @Router /v1/groups/{number}/{groupid}/refresh [post]
+func (a *Api) RefreshGroup(c *gin.Context) {
+	number := c.Param("number")
+	if number == "" {
+		c.JSON(400, Error{Msg: "Couldn't process request - number missing"})
+		return
+	}
+
+	groupId := c.Param("groupid")
+	internalGroupId, err := client.ConvertGroupIdToInternalGroupId(groupId)
+	if err != nil {
+		c.JSON(400, Error{Msg: err.Error()})
+		return
+	}
+
+	err = a.signalClient.RefreshGroup(number, internalGroupId)
+	if err != nil {
+		c.JSON(400, Error{Msg: err.Error()})
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
 // @Summary Send a reaction.
 // @Tags Reactions
 // @Description React to a message

--- a/src/client/client.go
+++ b/src/client/client.go
@@ -1220,7 +1220,7 @@ func (s *SignalClient) QuitGroup(number string, groupId string) error {
 	return err
 }
 
-func (s *SignalClient) RefreshGroup(number string, groupId string) error {
+func (s *SignalClient) UpdateGroup(number string, groupId string) error {
 	var err error
 	if s.signalCliMode == JsonRpc {
 		type Request struct {

--- a/src/client/client.go
+++ b/src/client/client.go
@@ -1220,6 +1220,24 @@ func (s *SignalClient) QuitGroup(number string, groupId string) error {
 	return err
 }
 
+func (s *SignalClient) RefreshGroup(number string, groupId string) error {
+	var err error
+	if s.signalCliMode == JsonRpc {
+		type Request struct {
+			GroupId string `json:"groupId"`
+		}
+		request := Request{GroupId: groupId}
+		jsonRpc2Client, err := s.getJsonRpc2Client(number)
+		if err != nil {
+			return err
+		}
+		_, err = jsonRpc2Client.getRaw("updateGroup", request)
+	} else {
+		_, err = s.cliClient.Execute(true, []string{"--config", s.signalCliConfig, "-a", number, "updateGroup", "-g", groupId}, "")
+	}
+	return err
+}
+
 func (s *SignalClient) SendReaction(number string, recipient string, emoji string, target_author string, timestamp int64, remove bool) error {
 	// see https://github.com/AsamK/signal-cli/blob/master/man/signal-cli.1.adoc#sendreaction
 	var err error

--- a/src/main.go
+++ b/src/main.go
@@ -186,6 +186,7 @@ func main() {
 			groups.POST(":number/:groupid/block", api.BlockGroup)
 			groups.POST(":number/:groupid/join", api.JoinGroup)
 			groups.POST(":number/:groupid/quit", api.QuitGroup)
+			groups.POST(":number/:groupid/refresh", api.RefreshGroup)
 			groups.POST(":number/:groupid/members", api.AddMembersToGroup)
 			groups.DELETE(":number/:groupid/members", api.RemoveMembersFromGroup)
 			groups.POST(":number/:groupid/admins", api.AddAdminsToGroup)

--- a/src/main.go
+++ b/src/main.go
@@ -186,7 +186,7 @@ func main() {
 			groups.POST(":number/:groupid/block", api.BlockGroup)
 			groups.POST(":number/:groupid/join", api.JoinGroup)
 			groups.POST(":number/:groupid/quit", api.QuitGroup)
-			groups.POST(":number/:groupid/refresh", api.RefreshGroup)
+			groups.PUT(":number/:groupid", api.UpdateGroup)
 			groups.POST(":number/:groupid/members", api.AddMembersToGroup)
 			groups.DELETE(":number/:groupid/members", api.RemoveMembersFromGroup)
 			groups.POST(":number/:groupid/admins", api.AddAdminsToGroup)


### PR DESCRIPTION
Hi there! I ran into a few issues where my bot's view of group membership would start to fall out of sync with reality. Adding/removing the bot from the group didn't fix things. I was able to find that there was a signal-cli command to re-sync the group state [here](https://github.com/AsamK/signal-cli/issues/1095#issuecomment-1309019924), but there didn't appear to be a way to trigger that from signal-cli-rest-api.

So, I just added a new endpoint `POST /v1/groups/{number}/{groupid}/refresh` that calls the appropriate refresh command. Can confirm that it works and helped solve some long-standing issues with my bots :)

Thanks for building and maintaining this project! It's been incredibly useful.