### PR TITLE
Allow updating group name

### DIFF
--- a/src/api/api.go
+++ b/src/api/api.go
@@ -50,7 +50,8 @@ type CreateGroupRequest struct {
 
 type UpdateGroupRequest struct {
 	Base64Avatar *string `json:"base64_avatar"`
-	Description *string `json:"description"`
+	Description  *string `json:"description"`
+	Name         *string `json:"name"`
 }
 
 type ChangeGroupMembersRequest struct {
@@ -1288,7 +1289,7 @@ func (a *Api) UpdateGroup(c *gin.Context) {
 		return
 	}
 
-	err = a.signalClient.UpdateGroup(number, internalGroupId, req.Base64Avatar, req.Description)
+	err = a.signalClient.UpdateGroup(number, internalGroupId, req.Base64Avatar, req.Description, req.Name)
 	if err != nil {
 		c.JSON(400, Error{Msg: err.Error()})
 		return

--- a/src/client/client.go
+++ b/src/client/client.go
@@ -1299,7 +1299,7 @@ func (s *SignalClient) QuitGroup(number string, groupId string) error {
 	return err
 }
 
-func (s *SignalClient) UpdateGroup(number string, groupId string, base64Avatar *string, groupDescription *string) error {
+func (s *SignalClient) UpdateGroup(number string, groupId string, base64Avatar *string, groupDescription *string, groupName *string) error {
 	var err error
 	var avatarTmpPath string = ""
 	if base64Avatar != nil {
@@ -1342,6 +1342,7 @@ func (s *SignalClient) UpdateGroup(number string, groupId string, base64Avatar *
 			GroupId     string `json:"groupId"`
 			Avatar      string `json:"avatar,omitempty"`
 			Description *string `json:"description,omitempty"`
+			Name        *string `json:"name,omitempty"`
 		}
 		request := Request{GroupId: groupId}
 
@@ -1350,6 +1351,7 @@ func (s *SignalClient) UpdateGroup(number string, groupId string, base64Avatar *
 		}
 
 		request.Description = groupDescription
+		request.Name = groupName
 
 
 		jsonRpc2Client, err := s.getJsonRpc2Client(number)
@@ -1366,6 +1368,11 @@ func (s *SignalClient) UpdateGroup(number string, groupId string, base64Avatar *
 		if groupDescription != nil {
 			cmd = append(cmd, []string{"-d", *groupDescription}...)
 		}
+
+		if groupName != nil {
+			cmd = append(cmd, []string{"-n", *groupName}...)
+		}
+
 		_, err = s.cliClient.Execute(true, cmd, "")
 	}
 

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -206,6 +206,8 @@ definitions:
         type: string
       description:
         type: string
+      name:
+        type: string
     type: object
   api.UpdateProfileRequest:
     properties:


### PR DESCRIPTION
`signal-cli` allows for updating the group name along with description and avatar
https://github.com/AsamK/signal-cli/blob/master/man/signal-cli.1.adoc#updategroup

this PR adds that functionality to signal-cli-rest-api