### PR TITLE
Link device in JSON-RPC mode

### DIFF
--- a/src/client/client.go
+++ b/src/client/client.go
@@ -1103,6 +1103,7 @@ func (s *SignalClient) GetQrCodeLink(deviceName string, qrCodeVersion int) ([]by
 				return
 			}
 			log.Debug("Linking device result: ", result)
+			s.signalCliApiConfig.Load(s.signalCliApiConfigPath)
 		})()
 
 		return png, nil


### PR DESCRIPTION
This PR adds the link-device functionality previously available in `native` to `json-rpc`. As signal-cli requires there to be a second request `finishLink` sent to actually link the device, this runs in a goroutine after the qr code is sent. The goroutine either finishes successfully, or dies after 1 minute due to signal-cli sending a failure message. (the result is available through debug logs).

To accomplish this, the `receivedMessages` chan had to be modified to actually be a map from "message id" (generated by us) to chan, indexed by the message receiver goroutine when a message is received and deleted after the result is parsed. 
This is because when there was an ongoing `finishLink` "job" running, the chan listener would eat all the other responses, so the service locked up while waiting for messages.

Closes #433 