### PR TITLE
Get list of accounts

### DIFF
--- a/src/api/api.go
+++ b/src/api/api.go
@@ -894,6 +894,23 @@ func (a *Api) GetQrCodeLink(c *gin.Context) {
 	c.Data(200, "image/png", png)
 }
 
+// @Summary List all accounts
+// @Tags Accounts
+// @Description Lists all of the accounts linked or registered
+// @Produce json
+// @Success 200 {object} []string
+// @Failure 400 {object} Error
+// @Router /v1/accounts [get]
+func (a *Api) GetAccounts(c *gin.Context) {
+	devices, err := a.signalClient.GetAccounts()
+	if err != nil {
+		c.JSON(500, Error{Msg: "Couldn't get list of accounts: " + err.Error()})
+		return
+	}
+
+	c.JSON(200, devices)
+}
+
 // @Summary List all attachments.
 // @Tags Attachments
 // @Description List all downloaded attachments

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -45,6 +45,35 @@ var doc = `{
                 }
             }
         },
+        "/v1/accounts": {
+            "get": {
+                "description": "Lists all of the devices linked or registered",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Accounts"
+                ],
+                "summary": "List all accounts",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/attachments": {
             "get": {
                 "description": "List all downloaded attachments",
@@ -1951,6 +1980,9 @@ var doc = `{
                 },
                 "description": {
                     "type": "string"
+                },
+                "name": {
+                    "type": "string"
                 }
             }
         },
@@ -2089,6 +2121,10 @@ var doc = `{
         {
             "description": "Register and link Devices.",
             "name": "Devices"
+        },
+        {
+            "description": "List registered and linked accounts",
+            "name": "Accounts"
         },
         {
             "description": "Create, List and Delete Signal Groups.",

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -29,6 +29,35 @@
                 }
             }
         },
+        "/v1/accounts": {
+            "get": {
+                "description": "Lists all of the devices linked or registered",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Accounts"
+                ],
+                "summary": "List all accounts",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/attachments": {
             "get": {
                 "description": "List all downloaded attachments",
@@ -1935,6 +1964,9 @@
                 },
                 "description": {
                     "type": "string"
+                },
+                "name": {
+                    "type": "string"
                 }
             }
         },
@@ -2073,6 +2105,10 @@
         {
             "description": "Register and link Devices.",
             "name": "Devices"
+        },
+        {
+            "description": "List registered and linked accounts",
+            "name": "Accounts"
         },
         {
             "description": "Create, List and Delete Signal Groups.",

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -311,6 +311,25 @@ paths:
       summary: Lists general information about the API
       tags:
       - General
+  /v1/accounts:
+    get:
+      description: Lists all of the devices linked or registered
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              type: string
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.Error'
+      summary: List all accounts
+      tags:
+      - Accounts
   /v1/attachments:
     get:
       description: List all downloaded attachments
@@ -1372,6 +1391,8 @@ tags:
   name: General
 - description: Register and link Devices.
   name: Devices
+- description: List registered and linked accounts
+  name: Accounts
 - description: Create, List and Delete Signal Groups.
   name: Groups
 - description: Send and Receive Signal Messages.

--- a/src/main.go
+++ b/src/main.go
@@ -28,6 +28,9 @@ import (
 // @tag.name Devices
 // @tag.description Register and link Devices.
 
+// @tag.name Accounts
+// @tag.description List registered and linked accounts
+
 // @tag.name Groups
 // @tag.description Create, List and Delete Signal Groups.
 
@@ -196,6 +199,11 @@ func main() {
 		link := v1.Group("qrcodelink")
 		{
 			link.GET("", api.GetQrCodeLink)
+		}
+
+		accounts := v1.Group("accounts")
+		{
+			accounts.GET("", api.GetAccounts)
 		}
 
 		devices := v1.Group("devices")


### PR DESCRIPTION
Adds `GET /v1/accounts` which returns an array of phone numbers (accounts) available to use.
[The main signal-cli manpage](https://github.com/AsamK/signal-cli/blob/master/man/signal-cli.1.adoc) does not reference this functionality, but [the manpage for the dbus API](https://github.com/AsamK/signal-cli/blob/master/man/signal-cli-dbus.5.adoc#signalcontrol-interface) does:

```
listAccounts() → accountList<as>
accountList : Array of all attached accounts in DBus object path form
```

Tested with both json-rpc and native mode, confirmed to show linked accounts, I sadly can't test it with number registrations, so it would be nice if somebody could confirm it works!

Also, I noticed that when running `swag i` on the latest version of swaggo, there are **a lot** of additional changes to the swagger spec. @bbernhard what version of swaggo are you using?
