### PR TITLE
Pass JAVA_OPTS through to signal-cli in json-rpc mode

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,6 +25,9 @@ caps="$cap_prefix$(seq -s ",$cap_prefix" 0 $(cat /proc/sys/kernel/cap_last_cap))
 if [ "$MODE" = "json-rpc" ]
 then
 /usr/bin/jsonrpc2-helper
+if [ -n "$JAVA_OPTS" ] ; then
+    echo "export JAVA_OPTS='$JAVA_OPTS'" >> /etc/default/supervisor
+fi
 service supervisor start
 supervisorctl start all
 fi


### PR DESCRIPTION
Fixes #473
