### PR TITLE
Add support for read receipts on /receive

### DIFF
--- a/src/api/api.go
+++ b/src/api/api.go
@@ -540,6 +540,7 @@ func StringToBool(input string) bool {
 // @Param ignore_attachments query string false "Specify whether the attachments of the received message should be ignored" (default: false)"
 // @Param ignore_stories query string false "Specify whether stories should be ignored when receiving messages" (default: false)"
 // @Param max_messages query string false "Specify the maximum number of messages to receive (default: unlimited)". Not available in json-rpc mode.
+// @Param send_read_receipts query string false "Specify whether read receipts should be sent when receiving messages" (default: false)"
 // @Router /v1/receive/{number} [get]
 func (a *Api) Receive(c *gin.Context) {
 	number := c.Param("number")
@@ -582,7 +583,13 @@ func (a *Api) Receive(c *gin.Context) {
 			return
 		}
 
-		jsonStr, err := a.signalClient.Receive(number, timeoutInt, StringToBool(ignoreAttachments), StringToBool(ignoreStories), maxMessagesInt)
+		sendReadReceipts := c.DefaultQuery("send_read_receipts", "false")
+		if sendReadReceipts != "true" && sendReadReceipts != "false" {
+			c.JSON(400, Error{Msg: "Couldn't process request - send_read_receipts parameter needs to be either 'true' or 'false'"})
+			return
+		}
+
+		jsonStr, err := a.signalClient.Receive(number, timeoutInt, StringToBool(ignoreAttachments), StringToBool(ignoreStories), maxMessagesInt, StringToBool(sendReadReceipts))
 		if err != nil {
 			c.JSON(400, Error{Msg: err.Error()})
 			return

--- a/src/client/client.go
+++ b/src/client/client.go
@@ -720,7 +720,7 @@ func (s *SignalClient) SendV2(number string, message string, recps []string, bas
 	return &timestamps, nil
 }
 
-func (s *SignalClient) Receive(number string, timeout int64, ignoreAttachments bool, ignoreStories bool, maxMessages int64) (string, error) {
+func (s *SignalClient) Receive(number string, timeout int64, ignoreAttachments bool, ignoreStories bool, maxMessages int64, sendReadReceipts bool) (string, error) {
 	if s.signalCliMode == JsonRpc {
 		return "", errors.New("Not implemented")
 	} else {
@@ -737,6 +737,10 @@ func (s *SignalClient) Receive(number string, timeout int64, ignoreAttachments b
 		if maxMessages > 0 {
 			command = append(command, "--max-messages")
 			command = append(command, strconv.FormatInt(maxMessages, 10))
+		}
+
+		if sendReadReceipts {
+			command = append(command, "--send-read-receipts")
 		}
 
 		out, err := s.cliClient.Execute(true, command, "")

--- a/src/main.go
+++ b/src/main.go
@@ -297,6 +297,7 @@ func main() {
 		autoReceiveScheduleReceiveTimeout := utils.GetEnv("AUTO_RECEIVE_SCHEDULE_RECEIVE_TIMEOUT", "10")
 		autoReceiveScheduleIgnoreAttachments := utils.GetEnv("AUTO_RECEIVE_SCHEDULE_IGNORE_ATTACHMENTS", "false")
 		autoReceiveScheduleIgnoreStories := utils.GetEnv("AUTO_RECEIVE_SCHEDULE_IGNORE_STORIES", "false")
+		autoReceiveScheduleSendReadReceipts := utils.GetEnv("AUTO_RECEIVE_SCHEDULE_SEND_READ_RECEIPTS", "false")
 
 		c := cron.New()
 		c.Schedule(schedule, cron.FuncJob(func() {
@@ -325,6 +326,7 @@ func main() {
 					q.Add("timeout", autoReceiveScheduleReceiveTimeout)
 					q.Add("ignore_attachments", autoReceiveScheduleIgnoreAttachments)
 					q.Add("ignore_stories", autoReceiveScheduleIgnoreStories)
+					q.Add("send_read_receipts", autoReceiveScheduleSendReadReceipts)
 					req.URL.RawQuery = q.Encode()
 
 					resp, err := client.Do(req)


### PR DESCRIPTION
Adds support for [sending read receipts](https://github.com/AsamK/signal-cli/blob/master/man/signal-cli.1.adoc#receive) on receive.

Closes #431

