### PR TITLE
Add a link to signal-cli-to-file

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,20 +104,26 @@ services:
       - "./signal-cli-config:/home/.local/share/signal-cli" #map "signal-cli-config" folder on host system into docker container. the folder contains the password and cryptographic keys when a new number is registered
 ```
 
-## Documentation
+## Documentation & Usage
 
 ### API Reference
 
 The Swagger API documentation can be found [here](https://bbernhard.github.io/signal-cli-rest-api/). If you prefer a simple text file based API documentation have a look [here](https://github.com/bbernhard/signal-cli-rest-api/blob/master/doc/EXAMPLES.md).
 
-### Utilities
-
-- [signal-cli-to-file](https://github.com/jneidel/signal-cli-to-file): save incoming signal messages as files
-
 ### Blog Posts
 
 - [Running Signal Messenger REST API in Azure Web App for Containers](https://stefanstranger.github.io/2021/06/01/RunningSignalRESTAPIinAppService/) by [@stefanstranger](https://github.com/stefanstranger)
 - [Sending Signal Messages](https://blog.aawadia.dev/2023/04/24/signal-api/) by [@asad-awadia](https://github.com/asad-awadia)
+
+### Clients, Libraries and Scripts
+
+|     Name    | Type | Language | Description |Maintainer |
+| ------------- |:------:|:-----:|---|:-----:|
+| [pysignalclirestapi](https://pypi.org/project/pysignalclirestapi/) | Library | Python | Small python library | [@bbernhard](https://github.com/bbernhard)
+| [signalbot](https://pypi.org/project/signalbot/) | Library | Python | Framework to build Signal bots | [@filipre](https://github.com/filipre)
+| [signal-cli-to-file](https://github.com/jneidel/signal-cli-to-file) | Script | JavaScript | Save incoming signal messages as files | [@jneidel](https://github.com/jneidel) |
+
+In case you need more functionality, please **file a ticket** or **create a PR**.
 
 ## Advanced Settings
 There are a bunch of environmental variables that can be set inside the docker container in order to change some technical details. This settings are meant for developers and advanced users. Usually you do *not* need to change anything here - the default values are perfectly fine!
@@ -131,12 +137,3 @@ There are a bunch of environmental variables that can be set inside the docker c
 * `SWAGGER_IP`: The IP that's used in the Swagger UI for the interactive examples. Defaults to the container ip.
 
 * `PORT`: Defaults to port `8080` unless this env var is set to tell it otherwise.
-
-## Clients & Libraries
-
-|     Name    | Client           | Library  | Language | Maintainer |
-| ------------- |:-------------:| :-----:|:-----:|:-----:|
-| [pysignalclirestapi](https://pypi.org/project/pysignalclirestapi/)      | | X | Python | [@bbernhard](https://github.com/bbernhard)
-| [signalbot](https://pypi.org/project/signalbot/) | | X | Python | [@filipre](https://github.com/filipre)
-
-In case you need more functionality, please **file a ticket** or **create a PR**.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ sudo docker run -d --name signal-api --restart=always -p 8080:8080 \
 
 3. Register or Link your Signal Number
 
-In this case we'll register our container as secondary device, assuming that you already have your primary number running / assigned to your mobile. 
+In this case we'll register our container as secondary device, assuming that you already have your primary number running / assigned to your mobile.
 
 Therefore open http://localhost:8080/v1/qrcodelink?device_name=signal-api in your browser, open Signal on your mobile phone, go to _Settings > Linked devices_ and scan the QR code using the _+_ button.
 
@@ -46,18 +46,18 @@ Call the REST API endpoint and send a test message: Replace `+4412345` with your
 
 ```bash
 $ curl -X POST -H "Content-Type: application/json" 'http://localhost:8080/v2/send' \
-     -d '{"message": "Test via Signal API!", "number": "+4412345", "recipients": [ "+44987654" ]}' 
+     -d '{"message": "Test via Signal API!", "number": "+4412345", "recipients": [ "+44987654" ]}'
 ```
 
 You should now have send a message to `+44987654`.
 
-## Execution Modes 
+## Execution Modes
 
 The `signal-cli-rest-api` supports three different modes of execution, which can be controlled by setting the `MODE` environment variable.
 
-* **`normal` Mode: (Default)** The `signal-cli` executable is invoked for every REST API request. Being a Java application, each REST call requires a new startup of the JVM (Java Virtual Machine), increasing the latency and hence leading to the slowest mode of operation. 
-* **`native` Mode:** A precompiled binary `signal-cli-native` (using GraalVM) is used for every REST API request. This results in a much lower latency & memory usage on each call. On the `armv7` platform this mode is not available and falls back to `normal`. The native mode may also be less stable, due to the experimental state of GraalVM compiler. 
-* `json-rpc` Mode: A single, JVM-based `signal-cli` instance is spawned as daemon process. This mode is usually the fastest, but requires more memory as the JVM keeps running. 
+* **`normal` Mode: (Default)** The `signal-cli` executable is invoked for every REST API request. Being a Java application, each REST call requires a new startup of the JVM (Java Virtual Machine), increasing the latency and hence leading to the slowest mode of operation.
+* **`native` Mode:** A precompiled binary `signal-cli-native` (using GraalVM) is used for every REST API request. This results in a much lower latency & memory usage on each call. On the `armv7` platform this mode is not available and falls back to `normal`. The native mode may also be less stable, due to the experimental state of GraalVM compiler.
+* `json-rpc` Mode: A single, JVM-based `signal-cli` instance is spawned as daemon process. This mode is usually the fastest, but requires more memory as the JVM keeps running.
 
 
 |     mode     |    speed    |    resident memory usage |
@@ -110,11 +110,14 @@ services:
 
 The Swagger API documentation can be found [here](https://bbernhard.github.io/signal-cli-rest-api/). If you prefer a simple text file based API documentation have a look [here](https://github.com/bbernhard/signal-cli-rest-api/blob/master/doc/EXAMPLES.md).
 
+### Utilities
+
+- [signal-cli-to-file](https://github.com/jneidel/signal-cli-to-file): save incoming signal messages as files
+
 ### Blog Posts
 
-[Running Signal Messenger REST API in Azure Web App for Containers](https://stefanstranger.github.io/2021/06/01/RunningSignalRESTAPIinAppService/) by [@stefanstranger](https://github.com/stefanstranger)
-
-[Sending Signal Messages](https://blog.aawadia.dev/2023/04/24/signal-api/) by [@asad-awadia](https://github.com/asad-awadia)
+- [Running Signal Messenger REST API in Azure Web App for Containers](https://stefanstranger.github.io/2021/06/01/RunningSignalRESTAPIinAppService/) by [@stefanstranger](https://github.com/stefanstranger)
+- [Sending Signal Messages](https://blog.aawadia.dev/2023/04/24/signal-api/) by [@asad-awadia](https://github.com/asad-awadia)
 
 ## Advanced Settings
 There are a bunch of environmental variables that can be set inside the docker container in order to change some technical details. This settings are meant for developers and advanced users. Usually you do *not* need to change anything here - the default values are perfectly fine!
@@ -127,8 +130,8 @@ There are a bunch of environmental variables that can be set inside the docker c
 
 * `SWAGGER_IP`: The IP that's used in the Swagger UI for the interactive examples. Defaults to the container ip.
 
-* `PORT`: Defaults to port `8080` unless this env var is set to tell it otherwise. 
-  
+* `PORT`: Defaults to port `8080` unless this env var is set to tell it otherwise.
+
 ## Clients & Libraries
 
 |     Name    | Client           | Library  | Language | Maintainer |


### PR DESCRIPTION
I wrote a utility script over at [signal-cli-to-file](https://github.com/jneidel/signal-cli-to-file) that receives incoming messages from signal-cli-rest-api and save them as files.

It's required for my basic use case for signal-cli:

> My use case is to write notes on my phone, take pictures or record audios that then just show up in my note-taking system. All very convieniently through signal.

Linking to it here so other people don't have to recreate it :smile: 