### PR TITLE
Add endpoint support for individual read receipts

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -49,6 +49,9 @@ import (
 // @tag.name Reactions
 // @tag.description React to messages.
 
+// @tag.name Receipts
+// @tag.description Send receipts for messages.
+
 // @tag.name Search
 // @tag.description Search the Signal Service.
 
@@ -252,6 +255,11 @@ func main() {
 		{
 			reactions.POST(":number", api.SendReaction)
 			reactions.DELETE(":number", api.RemoveReaction)
+		}
+
+		receipts := v1.Group("/receipts")
+		{
+			receipts.POST(":number", api.SendReceipt)
 		}
 
 		search := v1.Group("/search")


### PR DESCRIPTION
Added `POST /v1/receipt/{number}` endpoint to support read receipts for individual messages, as opposed to all received as currently exists with `/receive`. Complements functionality raised in #431 and #524.

Accepts a payload like:

```
{
  "receipt_type": "read",
  "recipient": "+12345678900",
  "timestamp": 1715386986897
}
```