### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ and [many more](https://bbernhard.github.io/signal-cli-rest-api/)
 This allows you to update `signal-cli-rest-api` by just deleting and recreating the container without the need to re-register your signal number
 
 ```bash
-$ mkdir $HOME/.local/share/signal-api
+$ mkdir -p $HOME/.local/share/signal-api
 ```
 
 


### PR DESCRIPTION
Fix:

without this flag, get this error:

```
~$ mkdir $HOME/.local/share/signal-api
mkdir: cannot create directory ‘/home/ubuntu/.local/share/signal-api’: No such file or directory
```