### PR TITLE
Expose listContacts endpoint

### DIFF
--- a/src/api/api.go
+++ b/src/api/api.go
@@ -1971,3 +1971,28 @@ func (a *Api) AddStickerPack(c *gin.Context) {
 
 	c.Status(201)
 }
+
+// @Summary List Contacts
+// @Tags Contacts
+// @Description List all contacts for the given number.
+// @Produce  json
+// @Success 200 {object} []client.ListContactsResponse
+// @Param number path string true "Registered Phone Number"
+// @Router /v1/contacts/{number} [get]
+func (a *Api) ListContacts(c *gin.Context) {
+	number := c.Param("number")
+
+	if number == "" {
+		c.JSON(400, Error{Msg: "Couldn't process request - number missing"})
+		return
+	}
+
+	contacts, err := a.signalClient.ListContacts(number)
+
+	if err != nil {
+		c.JSON(400, Error{Msg: err.Error()})
+		return
+	}
+
+	c.JSON(200, contacts)
+}

--- a/src/main.go
+++ b/src/main.go
@@ -270,6 +270,7 @@ func main() {
 
 		contacts := v1.Group("/contacts")
 		{
+			contacts.GET(":number", api.ListContacts)
 			contacts.PUT(":number", api.UpdateContact)
 			contacts.POST(":number/sync", api.SendContacts)
 		}


### PR DESCRIPTION
We are having this issue https://github.com/bbernhard/signal-cli-rest-api/issues/546 recently where we no longer receive the phone numbers in the signal-cli payload.

We are looking to adapt how we handle our onboarding. If a message is sent out to a username instead of a phone number, a contact is added, which includes the uuid and if we expose the `listContacts` command, we can save the uuid so that when we receive a message, we will be able to correctly identify the person.