### PR TITLE
For reverse proxies, add SWAGGER_HOST environment variable support

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ There are a bunch of environmental variables that can be set inside the docker c
 
 * `SIGNAL_CLI_GID`: Specifies the gid of the `signal-api` group inside the docker container. Defaults to `1000`
 
+* `SWAGGER_HOST`: The host that's used in the Swagger UI for the interactive examples (and useful when this runs behind a reverse proxy). Defaults to SWAGGER_IP:PORT.
+
 * `SWAGGER_IP`: The IP that's used in the Swagger UI for the interactive examples. Defaults to the container ip.
 
 * `PORT`: Defaults to port `8080` unless this env var is set to tell it otherwise.

--- a/src/main.go
+++ b/src/main.go
@@ -81,7 +81,8 @@ func main() {
 
 	defaultSwaggerIp := utils.GetEnv("HOST_IP", "127.0.0.1")
 	swaggerIp := utils.GetEnv("SWAGGER_IP", defaultSwaggerIp)
-	docs.SwaggerInfo.Host = swaggerIp + ":" + port
+	swaggerHost := utils.GetEnv("SWAGGER_HOST", swaggerIp+":"+port)
+	docs.SwaggerInfo.Host = swaggerHost
 
 	log.Info("Started Signal Messenger REST API")
 


### PR DESCRIPTION
I ran into the issue that I could not easily test this service behind a reverse proxy, because of the hard-coded `IP:PORT` set up. This should fix that. Please let me know if you need any other related changes before this can be accepted.

Changes:
- Add `SWAGGER_HOST` environment variable to `README.md` for Swagger UI configuration.
- Update `main.go` to use `SWAGGER_HOST` environment variable for Swagger UI host configuration.