### PR TITLE
Add support to disable notify-self flag on /v2/send endpoint

### DIFF
--- a/src/api/api.go
+++ b/src/api/api.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
-	"time"
 	"sync"
+	"time"
 
 	"github.com/gabriel-vasile/mimetype"
 	"github.com/gin-gonic/gin"
@@ -121,6 +121,7 @@ type SendMessageV2 struct {
 	QuoteMentions     []ds.MessageMention `json:"quote_mentions"`
 	TextMode          *string             `json:"text_mode" enums:"normal,styled"`
 	EditTimestamp     *int64              `json:"edit_timestamp"`
+	NotifySelf        *bool               `json:"notify_self"`
 }
 
 type TypingIndicatorRequest struct {
@@ -199,7 +200,7 @@ type AddStickerPackRequest struct {
 
 type Api struct {
 	signalClient *client.SignalClient
-	wsMutex sync.Mutex
+	wsMutex      sync.Mutex
 }
 
 func NewApi(signalClient *client.SignalClient) *Api {
@@ -418,7 +419,8 @@ func (a *Api) SendV2(c *gin.Context) {
 
 	data, err := a.signalClient.SendV2(
 		req.Number, req.Message, req.Recipients, req.Base64Attachments, req.Sticker,
-		req.Mentions, req.QuoteTimestamp, req.QuoteAuthor, req.QuoteMessage, req.QuoteMentions, req.TextMode, req.EditTimestamp)
+		req.Mentions, req.QuoteTimestamp, req.QuoteAuthor, req.QuoteMessage, req.QuoteMentions,
+		req.TextMode, req.EditTimestamp, req.NotifySelf)
 	if err != nil {
 		switch err.(type) {
 		case *client.RateLimitErrorType:

--- a/src/client/client.go
+++ b/src/client/client.go
@@ -562,7 +562,10 @@ func (s *SignalClient) send(signalCliSendRequest ds.SignalCliSendRequest) (*Send
 			cmd = append(cmd, strconv.FormatInt(*signalCliSendRequest.EditTimestamp, 10))
 		}
 
-		cmd = append(cmd, "--notify-self")
+		// for backwards compatibility, if nothing is set, use the notify-self flag
+		if signalCliSendRequest.NotifySelf == nil || *signalCliSendRequest.NotifySelf {
+			cmd = append(cmd, "--notify-self")
+		}
 
 		rawData, err := s.cliClient.Execute(true, cmd, signalCliSendRequest.Message)
 		if err != nil {
@@ -719,7 +722,7 @@ func (s *SignalClient) getJsonRpc2Clients() []*JsonRpc2Client {
 }
 
 func (s *SignalClient) SendV2(number string, message string, recps []string, base64Attachments []string, sticker string, mentions []ds.MessageMention,
-	quoteTimestamp *int64, quoteAuthor *string, quoteMessage *string, quoteMentions []ds.MessageMention, textMode *string, editTimestamp *int64) (*[]SendResponse, error) {
+	quoteTimestamp *int64, quoteAuthor *string, quoteMessage *string, quoteMentions []ds.MessageMention, textMode *string, editTimestamp *int64, notifySelf *bool) (*[]SendResponse, error) {
 	if len(recps) == 0 {
 		return nil, errors.New("Please provide at least one recipient")
 	}
@@ -770,7 +773,7 @@ func (s *SignalClient) SendV2(number string, message string, recps []string, bas
 		signalCliSendRequest := ds.SignalCliSendRequest{Number: number, Message: message, Recipients: []string{group}, Base64Attachments: base64Attachments,
 			RecipientType: ds.Group, Sticker: sticker, Mentions: mentions, QuoteTimestamp: quoteTimestamp,
 			QuoteAuthor: quoteAuthor, QuoteMessage: quoteMessage, QuoteMentions: quoteMentions,
-			TextMode: textMode, EditTimestamp: editTimestamp}
+			TextMode: textMode, EditTimestamp: editTimestamp, NotifySelf: notifySelf}
 		timestamp, err := s.send(signalCliSendRequest)
 		if err != nil {
 			return nil, err

--- a/src/datastructs/datastructs.go
+++ b/src/datastructs/datastructs.go
@@ -41,4 +41,5 @@ type SignalCliSendRequest struct {
 	QuoteMentions     []MessageMention
 	TextMode          *string
 	EditTimestamp     *int64
+	NotifySelf        *bool
 }

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -2282,6 +2282,9 @@ var doc = `{
                         "normal",
                         "styled"
                     ]
+                },
+                "notify_self": {
+                    "type": "boolean"
                 }
             }
         },

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -2266,6 +2266,9 @@
                         "normal",
                         "styled"
                     ]
+                },
+                "notify_self": {
+                    "type": "boolean"
                 }
             }
         },

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -195,6 +195,8 @@ definitions:
         - normal
         - styled
         type: string
+      notify_self:
+        type: boolean
     type: object
   api.SetUsernameRequest:
     properties:


### PR DESCRIPTION
Will allow you to send the `notify_self` property to the `/v2/send` endpoint. Leaving the field `null` or setting it to `true` will cause the current default behavior and should therefore be backwards compatible.

Setting it to `false` will prevent your devices from generating a notification when you send a message yourself.

The `notify_self` property controls whether the `--notify-self` flag is attached to the generated command (which currently is always the case).

Useful when you are using the API for both messages that you want to be notified about (for example when your home assistant sends out an alert) and ones you don't need to be alerted to (when using from a chat application where you compose messages yourself).

I have tried to autogenerate the documentation using swaggo/swag with version v1.8.10 but either the docs haven't been updated for a while or my configuration is wrong because the diff is pretty huge. If desired, I can still run `swag init`, although I'd be glad to know if there is something I should pay attention to config-wise.