### PR TITLE
Add ability to update about text in UpdateProfileRequest

### DIFF
--- a/src/api/api.go
+++ b/src/api/api.go
@@ -146,7 +146,7 @@ type CreateGroupResponse struct {
 type UpdateProfileRequest struct {
 	Name         string `json:"name"`
 	Base64Avatar string `json:"base64_avatar"`
-	About 			 string `json:"about"`
+	About 			 *string `json:"about"`
 }
 
 type TrustIdentityRequest struct {

--- a/src/api/api.go
+++ b/src/api/api.go
@@ -146,6 +146,7 @@ type CreateGroupResponse struct {
 type UpdateProfileRequest struct {
 	Name         string `json:"name"`
 	Base64Avatar string `json:"base64_avatar"`
+	About 			 string `json:"about"`
 }
 
 type TrustIdentityRequest struct {
@@ -1115,7 +1116,7 @@ func (a *Api) UpdateProfile(c *gin.Context) {
 		return
 	}
 
-	err = a.signalClient.UpdateProfile(number, req.Name, req.Base64Avatar)
+	err = a.signalClient.UpdateProfile(number, req.Name, req.Base64Avatar, req.About)
 	if err != nil {
 		c.JSON(400, Error{Msg: err.Error()})
 		return

--- a/src/client/client.go
+++ b/src/client/client.go
@@ -1356,7 +1356,7 @@ func (s *SignalClient) GetAttachment(attachment string) ([]byte, error) {
 	return attachmentBytes, nil
 }
 
-func (s *SignalClient) UpdateProfile(number string, profileName string, base64Avatar string) error {
+func (s *SignalClient) UpdateProfile(number string, profileName string, base64Avatar string, about string) error {
 	var err error
 	var avatarTmpPath string
 	if base64Avatar != "" {
@@ -1399,6 +1399,7 @@ func (s *SignalClient) UpdateProfile(number string, profileName string, base64Av
 			Name         string `json:"given-name"`
 			Avatar       string `json:"avatar,omitempty"`
 			RemoveAvatar bool   `json:"remove-avatar"`
+			About        string `json:"about"`
 		}
 		request := Request{Name: profileName}
 		if base64Avatar == "" {
@@ -1413,7 +1414,7 @@ func (s *SignalClient) UpdateProfile(number string, profileName string, base64Av
 		}
 		_, err = jsonRpc2Client.getRaw("updateProfile", &number, request)
 	} else {
-		cmd := []string{"--config", s.signalCliConfig, "-a", number, "updateProfile", "--given-name", profileName}
+		cmd := []string{"--config", s.signalCliConfig, "-a", number, "updateProfile", "--given-name", profileName, "--about", about}
 		if base64Avatar == "" {
 			cmd = append(cmd, "--remove-avatar")
 		} else {


### PR DESCRIPTION
@bbernhard We wanted to add the about text to the UpdateProfileRequest to be able to set this via signal-cli-rest-api.
I built the image and tested this with the about text and without and it seems to work on my end.