### PR TITLE
Swagger fixes

### DIFF
--- a/src/api/api.go
+++ b/src/api/api.go
@@ -1416,6 +1416,7 @@ func (a *Api) UpdateGroup(c *gin.Context) {
 // @Success 204 {string} OK
 // @Failure 400 {object} Error
 // @Param data body Reaction true "Reaction"
+// @Param id path int true "Reaction Identifier"
 // @Router /v1/reactions/{number} [post]
 func (a *Api) SendReaction(c *gin.Context) {
 	var req Reaction
@@ -1464,6 +1465,7 @@ func (a *Api) SendReaction(c *gin.Context) {
 // @Success 204 {string} OK
 // @Failure 400 {object} Error
 // @Param data body Reaction true "Reaction"
+// @Param id path int true "Reaction Identifier"
 // @Router /v1/reactions/{number} [delete]
 func (a *Api) RemoveReaction(c *gin.Context) {
 	var req Reaction
@@ -1507,6 +1509,7 @@ func (a *Api) RemoveReaction(c *gin.Context) {
 // @Success 204 {string} OK
 // @Failure 400 {object} Error
 // @Param data body Receipt true "Receipt"
+// @Param id path int true "Receipt Identifier"
 // @Router /v1/receipts/{number} [post]
 func (a *Api) SendReceipt(c *gin.Context) {
 	var req Receipt

--- a/src/api/api.go
+++ b/src/api/api.go
@@ -144,9 +144,9 @@ type CreateGroupResponse struct {
 }
 
 type UpdateProfileRequest struct {
-	Name         string `json:"name"`
-	Base64Avatar string `json:"base64_avatar"`
-	About 			 *string `json:"about"`
+	Name         string  `json:"name"`
+	Base64Avatar string  `json:"base64_avatar"`
+	About        *string `json:"about"`
 }
 
 type TrustIdentityRequest struct {
@@ -1416,7 +1416,7 @@ func (a *Api) UpdateGroup(c *gin.Context) {
 // @Success 204 {string} OK
 // @Failure 400 {object} Error
 // @Param data body Reaction true "Reaction"
-// @Param id path string true "Phone number"
+// @Param number path string true "Registered phone number"
 // @Router /v1/reactions/{number} [post]
 func (a *Api) SendReaction(c *gin.Context) {
 	var req Reaction
@@ -1465,7 +1465,7 @@ func (a *Api) SendReaction(c *gin.Context) {
 // @Success 204 {string} OK
 // @Failure 400 {object} Error
 // @Param data body Reaction true "Reaction"
-// @Param id path string true "Phone number"
+// @Param number path string true "Registered phone number"
 // @Router /v1/reactions/{number} [delete]
 func (a *Api) RemoveReaction(c *gin.Context) {
 	var req Reaction
@@ -1509,7 +1509,7 @@ func (a *Api) RemoveReaction(c *gin.Context) {
 // @Success 204 {string} OK
 // @Failure 400 {object} Error
 // @Param data body Receipt true "Receipt"
-// @Param id path string true "Phone number"
+// @Param number path string true "Registered phone number"
 // @Router /v1/receipts/{number} [post]
 func (a *Api) SendReceipt(c *gin.Context) {
 	var req Receipt

--- a/src/api/api.go
+++ b/src/api/api.go
@@ -1416,7 +1416,7 @@ func (a *Api) UpdateGroup(c *gin.Context) {
 // @Success 204 {string} OK
 // @Failure 400 {object} Error
 // @Param data body Reaction true "Reaction"
-// @Param id path int true "Reaction Identifier"
+// @Param id path string true "Phone number"
 // @Router /v1/reactions/{number} [post]
 func (a *Api) SendReaction(c *gin.Context) {
 	var req Reaction
@@ -1465,7 +1465,7 @@ func (a *Api) SendReaction(c *gin.Context) {
 // @Success 204 {string} OK
 // @Failure 400 {object} Error
 // @Param data body Reaction true "Reaction"
-// @Param id path int true "Reaction Identifier"
+// @Param id path string true "Phone number"
 // @Router /v1/reactions/{number} [delete]
 func (a *Api) RemoveReaction(c *gin.Context) {
 	var req Reaction
@@ -1509,7 +1509,7 @@ func (a *Api) RemoveReaction(c *gin.Context) {
 // @Success 204 {string} OK
 // @Failure 400 {object} Error
 // @Param data body Receipt true "Receipt"
-// @Param id path int true "Receipt Identifier"
+// @Param id path string true "Phone number"
 // @Router /v1/receipts/{number} [post]
 func (a *Api) SendReceipt(c *gin.Context) {
 	var req Receipt

--- a/src/docs/README.md
+++ b/src/docs/README.md
@@ -1,6 +1,6 @@
 These files are generated from the [swaggo/swag](https://github.com/swaggo/swag) tool.
 
-To regenerate them, run:
+To regenerate them, run in /src:
 
 ```bash
 docker run --rm -v $(pwd):/code ghcr.io/swaggo/swag:latest init

--- a/src/docs/README.md
+++ b/src/docs/README.md
@@ -1,0 +1,13 @@
+These files are generated from the [swaggo/swag](https://github.com/swaggo/swag) tool.
+
+To regenerate them, run:
+
+```bash
+docker run --rm -v $(pwd):/code ghcr.io/swaggo/swag:latest init
+```
+
+Or, if you have `swag` installed:
+
+```bash
+swag init
+```

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -1418,8 +1418,8 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Phone number",
-                        "name": "id",
+                        "description": "Registered phone number",
+                        "name": "number",
                         "in": "path",
                         "required": true
                     }
@@ -1463,8 +1463,8 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Phone number",
-                        "name": "id",
+                        "description": "Registered phone number",
+                        "name": "number",
                         "in": "path",
                         "required": true
                     }
@@ -1510,8 +1510,8 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Phone number",
-                        "name": "id",
+                        "description": "Registered phone number",
+                        "name": "number",
                         "in": "path",
                         "required": true
                     }

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -1417,8 +1417,8 @@ const docTemplate = `{
                         }
                     },
                     {
-                        "type": "integer",
-                        "description": "Reaction Identifier",
+                        "type": "string",
+                        "description": "Phone number",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -1462,8 +1462,8 @@ const docTemplate = `{
                         }
                     },
                     {
-                        "type": "integer",
-                        "description": "Reaction Identifier",
+                        "type": "string",
+                        "description": "Phone number",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -1509,8 +1509,8 @@ const docTemplate = `{
                         }
                     },
                     {
-                        "type": "integer",
-                        "description": "Receipt Identifier",
+                        "type": "string",
+                        "description": "Phone number",
                         "name": "id",
                         "in": "path",
                         "required": true

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -1415,6 +1415,13 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/api.Reaction"
                         }
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Reaction Identifier",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
                     }
                 ],
                 "responses": {
@@ -1453,6 +1460,13 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/api.Reaction"
                         }
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Reaction Identifier",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
                     }
                 ],
                 "responses": {
@@ -1493,6 +1507,13 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/api.Receipt"
                         }
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Receipt Identifier",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
                     }
                 ],
                 "responses": {
@@ -2278,69 +2299,7 @@ const docTemplate = `{
             }
         },
         "api.SendMessageV2": {
-            "type": "object",
-            "properties": {
-                "base64_attachments": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "example": [
-                        "\u003cBASE64 ENCODED DATA\u003e",
-                        "data:\u003cMIME-TYPE\u003e;base64\u003ccomma\u003e\u003cBASE64 ENCODED DATA\u003e",
-                        "data:\u003cMIME-TYPE\u003e;filename=\u003cFILENAME\u003e;base64\u003ccomma\u003e\u003cBASE64 ENCODED DATA\u003e"
-                    ]
-                },
-                "edit_timestamp": {
-                    "type": "integer"
-                },
-                "mentions": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/data.MessageMention"
-                    }
-                },
-                "message": {
-                    "type": "string"
-                },
-                "notify_self": {
-                    "type": "boolean"
-                },
-                "number": {
-                    "type": "string"
-                },
-                "quote_author": {
-                    "type": "string"
-                },
-                "quote_mentions": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/data.MessageMention"
-                    }
-                },
-                "quote_message": {
-                    "type": "string"
-                },
-                "quote_timestamp": {
-                    "type": "integer"
-                },
-                "recipients": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "sticker": {
-                    "type": "string"
-                },
-                "text_mode": {
-                    "type": "string",
-                    "enum": [
-                        "normal",
-                        "styled"
-                    ]
-                }
-            }
+            "type": "object"
         },
         "api.SetUsernameRequest": {
             "type": "object",
@@ -2442,6 +2401,9 @@ const docTemplate = `{
         "api.UpdateProfileRequest": {
             "type": "object",
             "properties": {
+                "about": {
+                    "type": "string"
+                },
                 "base64_avatar": {
                     "type": "string"
                 },
@@ -2610,20 +2572,6 @@ const docTemplate = `{
                     "type": "string"
                 }
             }
-        },
-        "data.MessageMention": {
-            "type": "object",
-            "properties": {
-                "author": {
-                    "type": "string"
-                },
-                "length": {
-                    "type": "integer"
-                },
-                "start": {
-                    "type": "integer"
-                }
-            }
         }
     },
     "tags": [
@@ -2681,9 +2629,9 @@ const docTemplate = `{
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
 	Version:          "1.0",
-	Host:             "",
+	Host:             "localhost:8080",
 	BasePath:         "/",
-	Schemes:          []string{},
+	Schemes:          []string{"http"},
 	Title:            "Signal Cli REST API",
 	Description:      "This is the Signal Cli REST API documentation.",
 	InfoInstanceName: "swagger",

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -2296,7 +2296,69 @@
             }
         },
         "api.SendMessageV2": {
-            "type": "object"
+            "type": "object",
+            "properties": {
+                "base64_attachments": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "\u003cBASE64 ENCODED DATA\u003e",
+                        "data:\u003cMIME-TYPE\u003e;base64\u003ccomma\u003e\u003cBASE64 ENCODED DATA\u003e",
+                        "data:\u003cMIME-TYPE\u003e;filename=\u003cFILENAME\u003e;base64\u003ccomma\u003e\u003cBASE64 ENCODED DATA\u003e"
+                    ]
+                },
+                "edit_timestamp": {
+                    "type": "integer"
+                },
+                "mentions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/data.MessageMention"
+                    }
+                },
+                "message": {
+                    "type": "string"
+                },
+                "notify_self": {
+                    "type": "boolean"
+                },
+                "number": {
+                    "type": "string"
+                },
+                "quote_author": {
+                    "type": "string"
+                },
+                "quote_mentions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/data.MessageMention"
+                    }
+                },
+                "quote_message": {
+                    "type": "string"
+                },
+                "quote_timestamp": {
+                    "type": "integer"
+                },
+                "recipients": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "sticker": {
+                    "type": "string"
+                },
+                "text_mode": {
+                    "type": "string",
+                    "enum": [
+                        "normal",
+                        "styled"
+                    ]
+                }
+            }
         },
         "api.SetUsernameRequest": {
             "type": "object",
@@ -2567,6 +2629,20 @@
                 },
                 "username_link": {
                     "type": "string"
+                }
+            }
+        },
+        "data.MessageMention": {
+            "type": "object",
+            "properties": {
+                "author": {
+                    "type": "string"
+                },
+                "length": {
+                    "type": "integer"
+                },
+                "start": {
+                    "type": "integer"
                 }
             }
         }

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -1414,8 +1414,8 @@
                         }
                     },
                     {
-                        "type": "integer",
-                        "description": "Reaction Identifier",
+                        "type": "string",
+                        "description": "Phone number",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -1459,8 +1459,8 @@
                         }
                     },
                     {
-                        "type": "integer",
-                        "description": "Reaction Identifier",
+                        "type": "string",
+                        "description": "Phone number",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -1506,8 +1506,8 @@
                         }
                     },
                     {
-                        "type": "integer",
-                        "description": "Receipt Identifier",
+                        "type": "string",
+                        "description": "Phone number",
                         "name": "id",
                         "in": "path",
                         "required": true

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -1,4 +1,7 @@
 {
+    "schemes": [
+        "http"
+    ],
     "swagger": "2.0",
     "info": {
         "description": "This is the Signal Cli REST API documentation.",
@@ -8,7 +11,6 @@
     },
     "host": "localhost:8080",
     "basePath": "/",
-    "schemes": ["http"],
     "paths": {
         "/v1/about": {
             "get": {
@@ -1403,13 +1405,6 @@
                 "summary": "Send a reaction.",
                 "parameters": [
                     {
-                        "description": "Reaction ID",
-                        "name": "number",
-                        "in": "path",
-                        "required": true,
-                        "type": "number"
-                    },
-                    {
                         "description": "Reaction",
                         "name": "data",
                         "in": "body",
@@ -1417,6 +1412,13 @@
                         "schema": {
                             "$ref": "#/definitions/api.Reaction"
                         }
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Reaction Identifier",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
                     }
                 ],
                 "responses": {
@@ -1448,13 +1450,6 @@
                 "summary": "Remove a reaction.",
                 "parameters": [
                     {
-                        "description": "Reaction ID",
-                        "name": "number",
-                        "in": "path",
-                        "required": true,
-                        "type": "number"
-                    },
-                    {
                         "description": "Reaction",
                         "name": "data",
                         "in": "body",
@@ -1462,6 +1457,13 @@
                         "schema": {
                             "$ref": "#/definitions/api.Reaction"
                         }
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Reaction Identifier",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
                     }
                 ],
                 "responses": {
@@ -1495,13 +1497,6 @@
                 "summary": "Send a receipt.",
                 "parameters": [
                     {
-                        "description": "Receipt ID",
-                        "name": "number",
-                        "in": "path",
-                        "required": true,
-                        "type": "number"
-                    },
-                    {
                         "description": "Receipt",
                         "name": "data",
                         "in": "body",
@@ -1509,6 +1504,13 @@
                         "schema": {
                             "$ref": "#/definitions/api.Receipt"
                         }
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Receipt Identifier",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
                     }
                 ],
                 "responses": {
@@ -1694,7 +1696,7 @@
                 }
             }
         },
-        "/v1/search/{number}": {
+        "/v1/search": {
             "get": {
                 "description": "Check if one or more phone numbers are registered with the Signal Service.",
                 "consumes": [
@@ -1712,8 +1714,7 @@
                         "type": "string",
                         "description": "Registered Phone Number",
                         "name": "number",
-                        "in": "path",
-                        "required": true
+                        "in": "path"
                     },
                     {
                         "type": "array",
@@ -2295,69 +2296,7 @@
             }
         },
         "api.SendMessageV2": {
-            "type": "object",
-            "properties": {
-                "base64_attachments": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "example": [
-                        "\u003cBASE64 ENCODED DATA\u003e",
-                        "data:\u003cMIME-TYPE\u003e;base64\u003ccomma\u003e\u003cBASE64 ENCODED DATA\u003e",
-                        "data:\u003cMIME-TYPE\u003e;filename=\u003cFILENAME\u003e;base64\u003ccomma\u003e\u003cBASE64 ENCODED DATA\u003e"
-                    ]
-                },
-                "edit_timestamp": {
-                    "type": "integer"
-                },
-                "mentions": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/data.MessageMention"
-                    }
-                },
-                "message": {
-                    "type": "string"
-                },
-                "notify_self": {
-                    "type": "boolean"
-                },
-                "number": {
-                    "type": "string"
-                },
-                "quote_author": {
-                    "type": "string"
-                },
-                "quote_mentions": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/data.MessageMention"
-                    }
-                },
-                "quote_message": {
-                    "type": "string"
-                },
-                "quote_timestamp": {
-                    "type": "integer"
-                },
-                "recipients": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "sticker": {
-                    "type": "string"
-                },
-                "text_mode": {
-                    "type": "string",
-                    "enum": [
-                        "normal",
-                        "styled"
-                    ]
-                }
-            }
+            "type": "object"
         },
         "api.SetUsernameRequest": {
             "type": "object",
@@ -2459,6 +2398,9 @@
         "api.UpdateProfileRequest": {
             "type": "object",
             "properties": {
+                "about": {
+                    "type": "string"
+                },
                 "base64_avatar": {
                     "type": "string"
                 },
@@ -2625,20 +2567,6 @@
                 },
                 "username_link": {
                     "type": "string"
-                }
-            }
-        },
-        "data.MessageMention": {
-            "type": "object",
-            "properties": {
-                "author": {
-                    "type": "string"
-                },
-                "length": {
-                    "type": "integer"
-                },
-                "start": {
-                    "type": "integer"
                 }
             }
         }

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -8,6 +8,7 @@
     },
     "host": "localhost:8080",
     "basePath": "/",
+    "schemes": ["http"],
     "paths": {
         "/v1/about": {
             "get": {

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -1401,6 +1401,13 @@
                 "summary": "Send a reaction.",
                 "parameters": [
                     {
+                        "description": "Reaction ID",
+                        "name": "number",
+                        "in": "path",
+                        "required": true,
+                        "type": "number"
+                    },
+                    {
                         "description": "Reaction",
                         "name": "data",
                         "in": "body",
@@ -1438,6 +1445,13 @@
                 ],
                 "summary": "Remove a reaction.",
                 "parameters": [
+                    {
+                        "description": "Reaction ID",
+                        "name": "number",
+                        "in": "path",
+                        "required": true,
+                        "type": "number"
+                    },
                     {
                         "description": "Reaction",
                         "name": "data",
@@ -1478,6 +1492,13 @@
                 ],
                 "summary": "Send a receipt.",
                 "parameters": [
+                    {
+                        "description": "Receipt ID",
+                        "name": "number",
+                        "in": "path",
+                        "required": true,
+                        "type": "number"
+                    },
                     {
                         "description": "Receipt",
                         "name": "data",
@@ -1671,7 +1692,7 @@
                 }
             }
         },
-        "/v1/search": {
+        "/v1/search/{number}": {
             "get": {
                 "description": "Check if one or more phone numbers are registered with the Signal Service.",
                 "consumes": [
@@ -1689,7 +1710,8 @@
                         "type": "string",
                         "description": "Registered Phone Number",
                         "name": "number",
-                        "in": "path"
+                        "in": "path",
+                        "required": true
                     },
                     {
                         "type": "array",

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -1415,8 +1415,8 @@
                     },
                     {
                         "type": "string",
-                        "description": "Phone number",
-                        "name": "id",
+                        "description": "Registered phone number",
+                        "name": "number",
                         "in": "path",
                         "required": true
                     }
@@ -1460,8 +1460,8 @@
                     },
                     {
                         "type": "string",
-                        "description": "Phone number",
-                        "name": "id",
+                        "description": "Registered phone number",
+                        "name": "number",
                         "in": "path",
                         "required": true
                     }
@@ -1507,8 +1507,8 @@
                     },
                     {
                         "type": "string",
-                        "description": "Phone number",
-                        "name": "id",
+                        "description": "Registered phone number",
+                        "name": "number",
                         "in": "path",
                         "required": true
                     }
@@ -2296,69 +2296,7 @@
             }
         },
         "api.SendMessageV2": {
-            "type": "object",
-            "properties": {
-                "base64_attachments": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "example": [
-                        "\u003cBASE64 ENCODED DATA\u003e",
-                        "data:\u003cMIME-TYPE\u003e;base64\u003ccomma\u003e\u003cBASE64 ENCODED DATA\u003e",
-                        "data:\u003cMIME-TYPE\u003e;filename=\u003cFILENAME\u003e;base64\u003ccomma\u003e\u003cBASE64 ENCODED DATA\u003e"
-                    ]
-                },
-                "edit_timestamp": {
-                    "type": "integer"
-                },
-                "mentions": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/data.MessageMention"
-                    }
-                },
-                "message": {
-                    "type": "string"
-                },
-                "notify_self": {
-                    "type": "boolean"
-                },
-                "number": {
-                    "type": "string"
-                },
-                "quote_author": {
-                    "type": "string"
-                },
-                "quote_mentions": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/data.MessageMention"
-                    }
-                },
-                "quote_message": {
-                    "type": "string"
-                },
-                "quote_timestamp": {
-                    "type": "integer"
-                },
-                "recipients": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "sticker": {
-                    "type": "string"
-                },
-                "text_mode": {
-                    "type": "string",
-                    "enum": [
-                        "normal",
-                        "styled"
-                    ]
-                }
-            }
+            "type": "object"
         },
         "api.SetUsernameRequest": {
             "type": "object",
@@ -2629,20 +2567,6 @@
                 },
                 "username_link": {
                     "type": "string"
-                }
-            }
-        },
-        "data.MessageMention": {
-            "type": "object",
-            "properties": {
-                "author": {
-                    "type": "string"
-                },
-                "length": {
-                    "type": "integer"
-                },
-                "start": {
-                    "type": "integer"
                 }
             }
         }

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -6,6 +6,7 @@
         "contact": {},
         "version": "1.0"
     },
+    "host": "localhost:8080",
     "basePath": "/",
     "paths": {
         "/v1/about": {

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -1,5 +1,7 @@
 host: localhost:8080
 basePath: /
+schemes:
+  - http
 definitions:
   api.AddDeviceRequest:
     properties:

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -1,7 +1,4 @@
-host: localhost:8080
 basePath: /
-schemes:
-  - http
 definitions:
   api.AddDeviceRequest:
     properties:
@@ -166,48 +163,6 @@ definitions:
         type: array
     type: object
   api.SendMessageV2:
-    properties:
-      base64_attachments:
-        example:
-        - <BASE64 ENCODED DATA>
-        - data:<MIME-TYPE>;base64<comma><BASE64 ENCODED DATA>
-        - data:<MIME-TYPE>;filename=<FILENAME>;base64<comma><BASE64 ENCODED DATA>
-        items:
-          type: string
-        type: array
-      edit_timestamp:
-        type: integer
-      mentions:
-        items:
-          $ref: '#/definitions/data.MessageMention'
-        type: array
-      message:
-        type: string
-      notify_self:
-        type: boolean
-      number:
-        type: string
-      quote_author:
-        type: string
-      quote_mentions:
-        items:
-          $ref: '#/definitions/data.MessageMention'
-        type: array
-      quote_message:
-        type: string
-      quote_timestamp:
-        type: integer
-      recipients:
-        items:
-          type: string
-        type: array
-      sticker:
-        type: string
-      text_mode:
-        enum:
-        - normal
-        - styled
-        type: string
     type: object
   api.SetUsernameRequest:
     properties:
@@ -274,6 +229,8 @@ definitions:
     type: object
   api.UpdateProfileRequest:
     properties:
+      about:
+        type: string
       base64_avatar:
         type: string
       name:
@@ -384,15 +341,7 @@ definitions:
       username_link:
         type: string
     type: object
-  data.MessageMention:
-    properties:
-      author:
-        type: string
-      length:
-        type: integer
-      start:
-        type: integer
-    type: object
+host: localhost:8080
 info:
   contact: {}
   description: This is the Signal Cli REST API documentation.
@@ -1332,17 +1281,17 @@ paths:
       - application/json
       description: Remove a reaction
       parameters:
-      - description: Reaction ID
-        name: number
-        in: path
-        required: true
-        type: number
       - description: Reaction
         in: body
         name: data
         required: true
         schema:
           $ref: '#/definitions/api.Reaction'
+      - description: Reaction Identifier
+        in: path
+        name: id
+        required: true
+        type: integer
       produces:
       - application/json
       responses:
@@ -1362,17 +1311,17 @@ paths:
       - application/json
       description: React to a message
       parameters:
-      - description: Reaction ID
-        name: number
-        in: path
-        required: true
-        type: number
       - description: Reaction
         in: body
         name: data
         required: true
         schema:
           $ref: '#/definitions/api.Reaction'
+      - description: Reaction Identifier
+        in: path
+        name: id
+        required: true
+        type: integer
       produces:
       - application/json
       responses:
@@ -1393,17 +1342,17 @@ paths:
       - application/json
       description: Send a read or viewed receipt
       parameters:
-      - description: Receipt ID
-        name: number
-        in: path
-        required: true
-        type: number
       - description: Receipt
         in: body
         name: data
         required: true
         schema:
           $ref: '#/definitions/api.Receipt'
+      - description: Receipt Identifier
+        in: path
+        name: id
+        required: true
+        type: integer
       produces:
       - application/json
       responses:
@@ -1532,7 +1481,7 @@ paths:
       summary: Verify a registered phone number.
       tags:
       - Devices
-  /v1/search/{number}:
+  /v1/search:
     get:
       consumes:
       - application/json
@@ -1543,7 +1492,6 @@ paths:
         in: path
         name: number
         type: string
-        required: true
       - collectionFormat: multi
         description: Numbers to check
         in: query
@@ -1775,6 +1723,8 @@ paths:
       summary: Send a signal message.
       tags:
       - Messages
+schemes:
+- http
 swagger: "2.0"
 tags:
 - description: Some general endpoints.

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -1,3 +1,4 @@
+host: localhost:8080
 basePath: /
 definitions:
   api.AddDeviceRequest:

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -163,48 +163,7 @@ definitions:
         type: array
     type: object
   api.SendMessageV2:
-    properties:
-      base64_attachments:
-        example:
-          - <BASE64 ENCODED DATA>
-          - data:<MIME-TYPE>;base64<comma><BASE64 ENCODED DATA>
-          - data:<MIME-TYPE>;filename=<FILENAME>;base64<comma><BASE64 ENCODED DATA>
-        items:
-          type: string
-        type: array
-      edit_timestamp:
-        type: integer
-      mentions:
-        items:
-          $ref: '#/definitions/data.MessageMention'
-        type: array
-      message:
-        type: string
-      notify_self:
-        type: boolean
-      number:
-        type: string
-      quote_author:
-        type: string
-      quote_mentions:
-        items:
-          $ref: '#/definitions/data.MessageMention'
-        type: array
-      quote_message:
-        type: string
-      quote_timestamp:
-        type: integer
-      recipients:
-        items:
-          type: string
-        type: array
-      sticker:
-        type: string
-      text_mode:
-        enum:
-          - normal
-          - styled
-        type: string
+    type: object
   api.SetUsernameRequest:
     properties:
       username:
@@ -382,14 +341,6 @@ definitions:
       username_link:
         type: string
     type: object
-  data.MessageMention:
-    properties:
-      author:
-        type: string
-      length:
-        type: integer
-      start:
-        type: integer
 host: localhost:8080
 info:
   contact: {}
@@ -1336,9 +1287,9 @@ paths:
         required: true
         schema:
           $ref: '#/definitions/api.Reaction'
-      - description: Phone number
+      - description: Registered phone number
         in: path
-        name: id
+        name: number
         required: true
         type: string
       produces:
@@ -1366,9 +1317,9 @@ paths:
         required: true
         schema:
           $ref: '#/definitions/api.Reaction'
-      - description: Phone number
+      - description: Registered phone number
         in: path
-        name: id
+        name: number
         required: true
         type: string
       produces:
@@ -1397,9 +1348,9 @@ paths:
         required: true
         schema:
           $ref: '#/definitions/api.Receipt'
-      - description: Phone number
+      - description: Registered phone number
         in: path
-        name: id
+        name: number
         required: true
         type: string
       produces:

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -163,7 +163,48 @@ definitions:
         type: array
     type: object
   api.SendMessageV2:
-    type: object
+    properties:
+      base64_attachments:
+        example:
+          - <BASE64 ENCODED DATA>
+          - data:<MIME-TYPE>;base64<comma><BASE64 ENCODED DATA>
+          - data:<MIME-TYPE>;filename=<FILENAME>;base64<comma><BASE64 ENCODED DATA>
+        items:
+          type: string
+        type: array
+      edit_timestamp:
+        type: integer
+      mentions:
+        items:
+          $ref: '#/definitions/data.MessageMention'
+        type: array
+      message:
+        type: string
+      notify_self:
+        type: boolean
+      number:
+        type: string
+      quote_author:
+        type: string
+      quote_mentions:
+        items:
+          $ref: '#/definitions/data.MessageMention'
+        type: array
+      quote_message:
+        type: string
+      quote_timestamp:
+        type: integer
+      recipients:
+        items:
+          type: string
+        type: array
+      sticker:
+        type: string
+      text_mode:
+        enum:
+          - normal
+          - styled
+        type: string
   api.SetUsernameRequest:
     properties:
       username:
@@ -341,6 +382,14 @@ definitions:
       username_link:
         type: string
     type: object
+  data.MessageMention:
+    properties:
+      author:
+        type: string
+      length:
+        type: integer
+      start:
+        type: integer
 host: localhost:8080
 info:
   contact: {}

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -1287,11 +1287,11 @@ paths:
         required: true
         schema:
           $ref: '#/definitions/api.Reaction'
-      - description: Reaction Identifier
+      - description: Phone number
         in: path
         name: id
         required: true
-        type: integer
+        type: string
       produces:
       - application/json
       responses:
@@ -1317,11 +1317,11 @@ paths:
         required: true
         schema:
           $ref: '#/definitions/api.Reaction'
-      - description: Reaction Identifier
+      - description: Phone number
         in: path
         name: id
         required: true
-        type: integer
+        type: string
       produces:
       - application/json
       responses:
@@ -1348,11 +1348,11 @@ paths:
         required: true
         schema:
           $ref: '#/definitions/api.Receipt'
-      - description: Receipt Identifier
+      - description: Phone number
         in: path
         name: id
         required: true
-        type: integer
+        type: string
       produces:
       - application/json
       responses:

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -1329,6 +1329,11 @@ paths:
       - application/json
       description: Remove a reaction
       parameters:
+      - description: Reaction ID
+        name: number
+        in: path
+        required: true
+        type: number
       - description: Reaction
         in: body
         name: data
@@ -1354,6 +1359,11 @@ paths:
       - application/json
       description: React to a message
       parameters:
+      - description: Reaction ID
+        name: number
+        in: path
+        required: true
+        type: number
       - description: Reaction
         in: body
         name: data
@@ -1380,6 +1390,11 @@ paths:
       - application/json
       description: Send a read or viewed receipt
       parameters:
+      - description: Receipt ID
+        name: number
+        in: path
+        required: true
+        type: number
       - description: Receipt
         in: body
         name: data
@@ -1514,7 +1529,7 @@ paths:
       summary: Verify a registered phone number.
       tags:
       - Devices
-  /v1/search:
+  /v1/search/{number}:
     get:
       consumes:
       - application/json
@@ -1525,6 +1540,7 @@ paths:
         in: path
         name: number
         type: string
+        required: true
       - collectionFormat: multi
         description: Numbers to check
         in: query

--- a/src/main.go
+++ b/src/main.go
@@ -58,6 +58,8 @@ import (
 // @tag.name Sticker Packs
 // @tag.description List and Install Sticker Packs
 
+// @host localhost:8080
+// @schemes http
 // @BasePath /
 func main() {
 	signalCliConfig := flag.String("signal-cli-config", "/home/.local/share/signal-cli/", "Config directory where signal-cli config is stored")


### PR DESCRIPTION
I use liblab to generate SDK clients from swagger. It complained about a few things that I had to fix. Some seemed like legitimate bugs, others I just added some placeholders.

1. Reaction and receipt endpoints were missing descriptions for their path parameters
2. Search endpoint had a description for its path parameter, but path parameter was not present in path
3. Host and scheme were missing (not sure if they are genuinely required in the spec but Liblab won't generate an SDK without them so hoping we can get them in too!)