### PR TITLE
Add notify-self-flag support for json-rpc mode

### DIFF
--- a/src/client/client.go
+++ b/src/client/client.go
@@ -461,7 +461,10 @@ func (s *SignalClient) send(signalCliSendRequest ds.SignalCliSendRequest) (*Send
 			request.Attachments = append(request.Attachments, attachmentEntry.toDataForSignal())
 		}
 
-		request.NotifySelf = true
+		// for backwards compatibility, if flag is not set we'll assume that self notification is desired
+		if signalCliSendRequest.NotifySelf == nil || *signalCliSendRequest.NotifySelf {
+			request.NotifySelf = true
+		}
 
 		request.Sticker = signalCliSendRequest.Sticker
 		if signalCliSendRequest.Mentions != nil {
@@ -1396,9 +1399,9 @@ func (s *SignalClient) UpdateProfile(number string, profileName string, base64Av
 
 	if s.signalCliMode == JsonRpc {
 		type Request struct {
-			Name         string `json:"given-name"`
-			Avatar       string `json:"avatar,omitempty"`
-			RemoveAvatar bool   `json:"remove-avatar"`
+			Name         string  `json:"given-name"`
+			Avatar       string  `json:"avatar,omitempty"`
+			RemoveAvatar bool    `json:"remove-avatar"`
 			About        *string `json:"about,omitempty"`
 		}
 		request := Request{Name: profileName}


### PR DESCRIPTION
Relates to #573, unfortunately I forgot to add the flag for the json-rpc mode which this PR will do. Should work the same, if the flag is not set, it should enable the self-notification by default so it is consistent with the existing behavior.