### PR TITLE
Path parameter in /v1/search is required

### DIFF
--- a/src/api/api.go
+++ b/src/api/api.go
@@ -1720,7 +1720,7 @@ func (a *Api) SendStopTyping(c *gin.Context) {
 // @Description Check if one or more phone numbers are registered with the Signal Service.
 // @Accept  json
 // @Produce  json
-// @Param number path string false "Registered Phone Number"
+// @Param number path string true "Registered Phone Number"
 // @Param numbers query []string true "Numbers to check" collectionFormat(multi)
 // @Success 200 {object} []SearchResponse
 // @Failure 400 {object} Error


### PR DESCRIPTION
# Problem

editor.swagger.io reports this error with the swagger.yml:
```
Structural error at paths./v1/search/{number}.get.parameters.0
should have required property 'required'
missingProperty: required
```

# Solution

Set the `required` parameter to `true` for the `/v1/search` endpoint.

# Comments

I tried to regenerate all the docs but get a bunch of other unnecessary changes so I'll leave that up to you @bbernhard - sorry!