### PR TITLE
New/changes endpoints for linking devices

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -230,6 +230,7 @@ func main() {
 		link := v1.Group("qrcodelink")
 		{
 			link.GET("", api.GetQrCodeLink)
+			link.GET("/raw", api.GetQrCodeLinkUri)
 		}
 
 		accounts := v1.Group("accounts")
@@ -247,6 +248,8 @@ func main() {
 		{
 			devices.POST(":number", api.AddDevice)
 			devices.GET(":number", api.ListDevices)
+			devices.DELETE(":number/:deviceId", api.RemoveDevice)
+			devices.DELETE(":number/local-data", api.DeleteLocalAccountData)
 		}
 
 		attachments := v1.Group("attachments")


### PR DESCRIPTION
This PR introduces improvements to the device linking workflow, including updates to existing endpoints and the addition of new ones to support more flexible device management.

Changed Endpoints

	•	/v1/devices/{number} (ListDevices)
The endpoint now returns the device ID, which is required by newly introduced endpoints.

New Endpoints

	•	/v1/qrcodelink/raw (GetQrCodeLinkUri)
Returns a device link URI that can be used directly by the device linking endpoint. Previously, the URI link was only possible via a QR code.

	•	/v1/devices/{number}/{deviceId} (RemoveDevice)
Removes a linked device from the master device using the device ID returned by ListDevices.

	•	/v1/devices/{number}/local-data (DeleteLocalAccountData)
Deletes the local database from the device. This is typically used after a device has been removed from the master device.

Testing

These changes were tested on ARM and x86_64 architectures, and in both normal and JSON-RPC modes.

