### PR TITLE
Update secured-signal-api (API Gateway)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The Swagger API documentation can be found [here](https://bbernhard.github.io/si
 | [signalbot](https://pypi.org/project/signalbot/)                         | Library |   Python   | Framework to build Signal bots         |       [@signalbot-org](https://github.com/orgs/signalbot-org/people)       |
 | [signal-cli-to-file](https://github.com/jneidel/signal-cli-to-file)      | Script  | JavaScript | Save incoming signal messages as files |       [@jneidel](https://github.com/jneidel)       |
 | [signal-rest-ts](https://www.npmjs.com/package/signal-rest-ts)           | Library | TypeScript | TypeScript module to build Signal bots | [@pseudogeneric](https://github.com/pseudogeneric) |
-| [secured-signal-api](https://github.com/codeshelldev/secured-signal-api) |  Proxy  |     Go     | Secure Docker Proxy with many QoL Features |  [@codeshelldev](https://github.com/codeshelldev)  |
+| [secured-signal-api](https://github.com/codeshelldev/secured-signal-api) |  API Gateway  |     Go     | Secure Docker API Gateway with many QoL Features |  [@codeshelldev](https://github.com/codeshelldev)  |
 
 In case you need more functionality, please **file a ticket** or **create a PR**.
 


### PR DESCRIPTION
Hey there!

I have just noticed that secured-signal-api isn‘t really a reverse proxy, since it doesn‘t handle SSL and just manages access and unifies data mappings for the API.

Therefor I have changed the description in the README.

_Before merging I will have to do some rebranding on my part, but I will mark it as ready-to-review as soon as that happens!_