### PR TITLE
Enable verbose logging in `signal-cli` if log level is debug

### DIFF
--- a/src/client/cli.go
+++ b/src/client/cli.go
@@ -89,6 +89,10 @@ func (s *CliClient) Execute(wait bool, args []string, stdin string) (string, err
 		args = append([]string{"--trust-new-identities", trustModeStr}, args...)
 	}
 
+	if log.GetLevel() >= log.DebugLevel {
+		args = append([]string{"--verbose"}, args...)
+	}
+
 	fullCmd := ""
 	if stdin != "" {
 		fullCmd += "echo '" + stdin + "' | "

--- a/src/scripts/jsonrpc2-helper.go
+++ b/src/scripts/jsonrpc2-helper.go
@@ -14,7 +14,7 @@ import (
 const supervisorctlConfigTemplate = `
 [program:%s]
 process_name=%s
-command=signal-cli --output=json --config %s%s daemon %s%s --tcp 127.0.0.1:%d
+command=signal-cli%s --output=json --config %s%s daemon %s%s --tcp 127.0.0.1:%d
 autostart=true
 autorestart=true
 startretries=10
@@ -78,6 +78,11 @@ func main() {
 		log.Fatal("Couldn't create log folder ", supervisorctlLogFolder, ": ", err.Error())
 	}
 
+	verbose := ""
+	if utils.GetEnv("LOG_LEVEL", "") == "debug" {
+		verbose = " --verbose"
+	}
+
 	trustNewIdentities := ""
 	trustNewIdentitiesEnv := utils.GetEnv("JSON_RPC_TRUST_NEW_IDENTITIES", "")
 	if trustNewIdentitiesEnv == "on-first-use" {
@@ -96,7 +101,7 @@ func main() {
 	supervisorctlConfigFilename := "/etc/supervisor/conf.d/" + "signal-cli-json-rpc-1.conf"
 
 	supervisorctlConfig := fmt.Sprintf(supervisorctlConfigTemplate, supervisorctlProgramName, supervisorctlProgramName,
-		signalCliConfigDir, trustNewIdentities, signalCliIgnoreAttachments, signalCliIgnoreStories, tcpPort,
+		verbose, signalCliConfigDir, trustNewIdentities, signalCliIgnoreAttachments, signalCliIgnoreStories, tcpPort,
 		supervisorctlProgramName, supervisorctlProgramName)
 
 	err = ioutil.WriteFile(supervisorctlConfigFilename, []byte(supervisorctlConfig), 0644)


### PR DESCRIPTION
*Feel free to reject if this isn't desired.*

If the log level is `debug` (either with the `LOG_LEVEL` environment variable or configuration option), enable verbose logging in `signal-cli`.

I thought it'd be useful to enable verbose logging in `signal-cli`. This does that automatically.
