### PR TITLE
Mark name and members as optional fields in CreateGroupRequest

### DIFF
--- a/src/api/api.go
+++ b/src/api/api.go
@@ -39,8 +39,8 @@ type UpdateContactRequest struct {
 }
 
 type CreateGroupRequest struct {
-	Name           string              `json:"name"`
-	Members        []string            `json:"members"`
+	Name           string              `json:"name,omitempty"`
+	Members        []string            `json:"members,omitempty"`
 	Description    string              `json:"description,omitempty"`
 	Permissions    ds.GroupPermissions `json:"permissions,omitempty"`
 	GroupLinkState string              `json:"group_link,omitempty" enums:"disabled,enabled,enabled-with-approval"`

--- a/src/client/client.go
+++ b/src/client/client.go
@@ -1080,8 +1080,8 @@ func (s *SignalClient) CreateGroup(number string, name string, members []string,
 	var internalGroupId string
 	if s.signalCliMode == JsonRpc {
 		type Request struct {
-			Name                    string   `json:"name"`
-			Members                 []string `json:"members"`
+			Name                    string   `json:"name,omitempty"`
+			Members                 []string `json:"members,omitempty"`
 			Link                    string   `json:"link,omitempty"`
 			Description             string   `json:"description,omitempty"`
 			EditGroupPermissions    string   `json:"setPermissionEditDetails,omitempty"`
@@ -1135,8 +1135,16 @@ func (s *SignalClient) CreateGroup(number string, name string, members []string,
 		}
 		internalGroupId = resp.GroupId
 	} else {
-		cmd := []string{"--config", s.signalCliConfig, "-a", number, "updateGroup", "-n", name, "-m"}
-		cmd = append(cmd, prefixUsernameMembers(members)...)
+		cmd := []string{"--config", s.signalCliConfig, "-a", number, "updateGroup"}
+
+		if name != "" {
+			cmd = append(cmd, []string{"--n", name}...)
+		}
+
+		if len(members) > 0 {
+			cmd = append(cmd, "-m")
+			cmd = append(cmd, prefixUsernameMembers(members)...)
+		}
 
 		if addMembersPermission != DefaultGroupPermission {
 			cmd = append(cmd, []string{"--set-permission-add-member", addMembersPermission.String()}...)

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -2790,10 +2790,6 @@ const docTemplate = `{
         },
         "api.CreateGroupRequest": {
             "type": "object",
-            "required": [
-                "members",
-                "name"
-            ],
             "properties": {
                 "description": {
                     "type": "string"

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -2787,10 +2787,6 @@
         },
         "api.CreateGroupRequest": {
             "type": "object",
-            "required": [
-                "members",
-                "name"
-            ],
             "properties": {
                 "description": {
                     "type": "string"

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -76,9 +76,6 @@ definitions:
         type: string
       permissions:
         $ref: '#/definitions/data.GroupPermissions'
-    required:
-    - members
-    - name
     type: object
   api.CreateGroupResponse:
     properties:


### PR DESCRIPTION
Following the discussions in https://github.com/bbernhard/signal-cli-rest-api/pull/828#discussion_r3047189125 this PR marks the `Name` and `Members` arguments of the `CreateGroupRequest` as optional.

For the native mode, luckily, signal-cli would just accept being called with `signal-cli updateGroup -n -m` and create an empty group. However, instead of relying on that behaviour to continue to work in the future this PR avoids calling `signal-cli` with empty parameters.