### PR TITLE
feat: deploy pages with CI

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,37 @@
+name: Deploy API Docs to GitHub Pages
+
+on:
+  release:
+    types:
+      - published
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v6
+
+      - name: Build static documentation bundle
+        run: src/docs/build-static-bundle.sh site "${{ github.event.release.tag_name }}"
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/src/docs/build-static-bundle.sh
+++ b/src/docs/build-static-bundle.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DOCS_DIR="$ROOT_DIR/src/docs"
+INDEX_FILE="$DOCS_DIR/index.html"
+OUT_DIR="${1:?output directory argument is required}"
+DOCS_VERSION="${2:?docs version argument is required}"
+NORMALIZED_DOCS_VERSION="${DOCS_VERSION#v}"
+
+echo "Normalized docs version: $NORMALIZED_DOCS_VERSION"
+
+rm -rf "$OUT_DIR"
+mkdir -p "$OUT_DIR"
+
+cp "$DOCS_DIR/swagger.json" "$OUT_DIR/swagger.json"
+cp "$INDEX_FILE" "$OUT_DIR/index.html"
+touch "$OUT_DIR/.nojekyll"
+
+jq --arg version "$NORMALIZED_DOCS_VERSION" '.info.version = $version' "$OUT_DIR/swagger.json" > "$OUT_DIR/swagger.json.tmp"
+mv "$OUT_DIR/swagger.json.tmp" "$OUT_DIR/swagger.json"
+
+echo "Static bundle created at: $OUT_DIR"

--- a/src/docs/index.html
+++ b/src/docs/index.html
@@ -11,7 +11,7 @@
             window.onload = function () {
                 // Begin Swagger UI call region
                 const ui = SwaggerUIBundle({
-                    url: "src/docs/swagger.json", //Location of Open API spec in the repo
+                    url: "swagger.json",
                     dom_id: '#swagger-ui',
                     deepLinking: true,
                     presets: [


### PR DESCRIPTION
This PR builds the docs on each release via a CI workflow. This has a few advantages over the current approach:

1. The build process is faster because the pages artifact only includes the index.html and the swagger.json instead of the whole repository
3. The pages only contain the changes from the latest release instead of whatever is currently in master
4. The dynamic version setting that I did in #830 only works for local deployments of the page. If you go to https://bbernhard.github.io/signal-cli-rest-api/ it still shows version `1.0`. The approach in this PR modifies the version in the swagger.json so that it is updated also in the github pages.

You will have to change the settings for this work. So in Settings -> Pages -> Build and deployment -> Source change it from `Deploy from branch` to `Github actions`.

When testing this github was a bit funny about it. You might need to manually unpublish and republish the page when doing the switch.

Here is the workflow running on my fork https://github.com/Gara-Dorta/signal-cli-rest-api/actions/runs/25430692982
Here is the generated page https://gara-dorta.github.io/signal-cli-rest-api/