### PR TITLE
Add update docs ci

### DIFF
--- a/.github/workflows/update-generated-docs.yml
+++ b/.github/workflows/update-generated-docs.yml
@@ -1,0 +1,41 @@
+name: Update Generated Docs
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-docs:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: src/go.mod
+          cache-dependency-path: src/go.sum
+
+      - name: Regenerate docs
+        working-directory: src
+        run: go run github.com/swaggo/swag/cmd/swag@v1.16.6 init --requiredByDefault
+
+      - name: Create pull request for regenerated docs
+        uses: peter-evans/create-pull-request@v8
+        with:
+          branch: automation/update-generated-docs
+          delete-branch: true
+          commit-message: "chore: regenerate swagger docs"
+          title: "chore: regenerate swagger docs"
+          body: |
+            Update Swagger docs to match the latest changes in the main branch.
+          add-paths: |
+            src/docs/docs.go
+            src/docs/swagger.json
+            src/docs/swagger.yaml


### PR DESCRIPTION
I decided not to wait for #842 to get merged and already add a workflow that updates the docs on each push to master. The workflow will create a PR if there are any changes and do nothing otherwise.

Here is an example of the PRs that it generates (please only look at the last commit and the body of the message, I was messing up with the master branch to test this feature) https://github.com/Gara-Dorta/signal-cli-rest-api/pull/1
That was generated by this job https://github.com/Gara-Dorta/signal-cli-rest-api/actions/runs/25432716226

Here is a job for a commit where there are no changes in the docs https://github.com/Gara-Dorta/signal-cli-rest-api/actions/runs/25432618000

I think it is easier to review as it is smaller PRs this way.