### PR TITLE
Pin actions/checkout to a commit SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs: setup
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.ref }}
       - name: Login to Docker Hub

--- a/.github/workflows/release-dev-version.yml
+++ b/.github/workflows/release-dev-version.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs: setup
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.ref }}
       - name: Login to Docker Hub

--- a/.github/workflows/release-productive-version.yml
+++ b/.github/workflows/release-productive-version.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs: setup
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.ref }}
       - name: Login to Docker Hub


### PR DESCRIPTION
Follow-up to #838 to try and harden against supply chain attacks.

`actions/checkout` is the only third-party action still on a mutable ref.

A force-push or compromise of `actions/checkout`'s default branch would execute attacker code. Downstream pulls of `:latest` would then carry a poisoned image.

This PR pins all three references to `v6.0.2`'s commit SHA (`de0fac2e4500dabe0009e67214ff5f5447ce83dd`).

---
 What this changes operationally                                                                                                                                   
                                 
  - No change on every commit or release of this repo. The actions/checkout SHA is decoupled from your source; bumping signal-cli-rest-api versions, merging unrelated PRs, or pushing to any branch does not require touching it. You only update it when you want a newer actions/checkout release.
  - Optional: let Dependabot do it. This repo doesn't have .github/dependabot.yml yet. Adding one with package-ecosystem: github-actions (≈5 lines) makes Dependabot open a bump PR every time actions/checkout ships a release.
