### PR TITLE
Add empty permissions block at workflow level

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
     branches:
       - '**' #every branch
 
+permissions: {}
+
 jobs:
   setup:
     runs-on: ubuntu-24.04

--- a/.github/workflows/release-dev-version.yml
+++ b/.github/workflows/release-dev-version.yml
@@ -4,8 +4,10 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version'     
+        description: 'Version'
         required: true
+
+permissions: {}
 
 
 jobs:

--- a/.github/workflows/release-productive-version.yml
+++ b/.github/workflows/release-productive-version.yml
@@ -4,8 +4,10 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version'     
+        description: 'Version'
         required: true
+
+permissions: {}
 
 
 jobs:


### PR DESCRIPTION
None of the three workflows currently declare a top-level `permissions:` block, so they inherit the repo default for `GITHUB_TOKEN`. 

It seems like none of them need any GitHub API write scope, since they only push to Docker Hub

This caps the blast radius if `GITHUB_TOKEN` ever leaks.