### PR TITLE
Group member label support

### DIFF
--- a/doc/EXAMPLES.md
+++ b/doc/EXAMPLES.md
@@ -115,6 +115,16 @@ e.g:
 
   `curl -X GET -H "Content-Type: application/json" 'http://127.0.0.1:8080/v1/groups/+431212131491291'`
 
+- Update your group member label
+
+  Updates the member label for the registered number in the given group. The group id can be obtained via the "List groups" REST call.
+
+  `curl -X PUT -H "Content-Type: application/json" -d '{"member_label": "<label>", "member_label_emoji": "<emoji>"}' 'http://127.0.0.1:8080/v1/groups/<number>/<group id>'`
+
+  e.g:
+
+  `curl -X PUT -H "Content-Type: application/json" -d '{"member_label": "Dad", "member_label_emoji": "👨‍👧"}' 'http://127.0.0.1:8080/v1/groups/+431212131491291/<group id>'`
+
 - Delete a group
 
   Delete the group with the given group id. The group id can be obtained via the "List groups" REST call.

--- a/doc/EXAMPLES.md
+++ b/doc/EXAMPLES.md
@@ -119,11 +119,11 @@ e.g:
 
   Updates the member label for the registered number in the given group. The group id can be obtained via the "List groups" REST call.
 
-  `curl -X PUT -H "Content-Type: application/json" -d '{"member_label": "<label>", "member_label_emoji": "<emoji>"}' 'http://127.0.0.1:8080/v1/groups/<number>/<group id>'`
+  `curl -X PUT -H "Content-Type: application/json" -d '{"member_label": {"name": "<label>", "emoji": "<emoji>"}}' 'http://127.0.0.1:8080/v1/groups/<number>/<group id>'`
 
   e.g:
 
-  `curl -X PUT -H "Content-Type: application/json" -d '{"member_label": "Dad", "member_label_emoji": "👨‍👧"}' 'http://127.0.0.1:8080/v1/groups/+431212131491291/<group id>'`
+  `curl -X PUT -H "Content-Type: application/json" -d '{"member_label": {"name": "Dad", "emoji": "👨‍👧"}}' 'http://127.0.0.1:8080/v1/groups/+431212131491291/<group id>'`
 
 - Delete a group
 

--- a/src/api/api.go
+++ b/src/api/api.go
@@ -48,12 +48,14 @@ type CreateGroupRequest struct {
 }
 
 type UpdateGroupRequest struct {
-	Base64Avatar   *string              `json:"base64_avatar,omitempty"`
-	Description    *string              `json:"description,omitempty"`
-	Name           *string              `json:"name,omitempty"`
-	ExpirationTime *int                 `json:"expiration_time,omitempty"`
-	GroupLinkState *string              `json:"group_link,omitempty" enums:"disabled,enabled,enabled-with-approval"`
-	Permissions    *ds.GroupPermissions `json:"permissions,omitempty"`
+	Base64Avatar     *string              `json:"base64_avatar,omitempty"`
+	Description      *string              `json:"description,omitempty"`
+	Name             *string              `json:"name,omitempty"`
+	MemberLabel      *string              `json:"member_label,omitempty"`
+	MemberLabelEmoji *string              `json:"member_label_emoji,omitempty"`
+	ExpirationTime   *int                 `json:"expiration_time,omitempty"`
+	GroupLinkState   *string              `json:"group_link,omitempty" enums:"disabled,enabled,enabled-with-approval"`
+	Permissions      *ds.GroupPermissions `json:"permissions,omitempty"`
 }
 
 type PinMessageInGroupRequest struct {
@@ -1860,7 +1862,7 @@ func (a *Api) UpdateGroup(c *gin.Context) {
 	}
 
 	err = a.signalClient.UpdateGroup(number, internalGroupId, req.Base64Avatar, req.Description, req.Name, req.ExpirationTime, groupLinkState,
-		editGroupPermission, addMembersPermission, sendMessagesPermission)
+		editGroupPermission, addMembersPermission, sendMessagesPermission, req.MemberLabel, req.MemberLabelEmoji)
 	if err != nil {
 		c.JSON(400, Error{Msg: err.Error()})
 		return

--- a/src/api/api.go
+++ b/src/api/api.go
@@ -47,15 +47,19 @@ type CreateGroupRequest struct {
 	ExpirationTime *int                `json:"expiration_time,omitempty"`
 }
 
+type MemberLabel struct {
+	Name  *string `json:"name,omitempty"`
+	Emoji *string `json:"emoji,omitempty"`
+}
+
 type UpdateGroupRequest struct {
-	Base64Avatar     *string              `json:"base64_avatar,omitempty"`
-	Description      *string              `json:"description,omitempty"`
-	Name             *string              `json:"name,omitempty"`
-	MemberLabel      *string              `json:"member_label,omitempty"`
-	MemberLabelEmoji *string              `json:"member_label_emoji,omitempty"`
-	ExpirationTime   *int                 `json:"expiration_time,omitempty"`
-	GroupLinkState   *string              `json:"group_link,omitempty" enums:"disabled,enabled,enabled-with-approval"`
-	Permissions      *ds.GroupPermissions `json:"permissions,omitempty"`
+	Base64Avatar   *string              `json:"base64_avatar,omitempty"`
+	Description    *string              `json:"description,omitempty"`
+	Name           *string              `json:"name,omitempty"`
+	MemberLabel    *MemberLabel         `json:"member_label,omitempty"`
+	ExpirationTime *int                 `json:"expiration_time,omitempty"`
+	GroupLinkState *string              `json:"group_link,omitempty" enums:"disabled,enabled,enabled-with-approval"`
+	Permissions    *ds.GroupPermissions `json:"permissions,omitempty"`
 }
 
 type PinMessageInGroupRequest struct {
@@ -1861,8 +1865,15 @@ func (a *Api) UpdateGroup(c *gin.Context) {
 		}
 	}
 
+	var memberLabel *string
+	var memberLabelEmoji *string
+	if req.MemberLabel != nil {
+		memberLabel = req.MemberLabel.Name
+		memberLabelEmoji = req.MemberLabel.Emoji
+	}
+
 	err = a.signalClient.UpdateGroup(number, internalGroupId, req.Base64Avatar, req.Description, req.Name, req.ExpirationTime, groupLinkState,
-		editGroupPermission, addMembersPermission, sendMessagesPermission, req.MemberLabel, req.MemberLabelEmoji)
+		editGroupPermission, addMembersPermission, sendMessagesPermission, memberLabel, memberLabelEmoji)
 	if err != nil {
 		c.JSON(400, Error{Msg: err.Error()})
 		return

--- a/src/api/api_test.go
+++ b/src/api/api_test.go
@@ -1,0 +1,27 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestUpdateGroupRequestMemberLabel(t *testing.T) {
+	var req UpdateGroupRequest
+	rawRequest := []byte(`{"member_label":{"name":"Dad","emoji":"\ud83d\udc4b"}}`)
+
+	if err := json.Unmarshal(rawRequest, &req); err != nil {
+		t.Fatalf("json.Unmarshal() error: %v", err)
+	}
+
+	if req.MemberLabel == nil {
+		t.Fatal("member_label got nil, want value")
+	}
+
+	if req.MemberLabel.Name == nil || *req.MemberLabel.Name != "Dad" {
+		t.Fatalf("member_label.name got %v, want Dad", req.MemberLabel.Name)
+	}
+
+	if req.MemberLabel.Emoji == nil || *req.MemberLabel.Emoji != "\U0001F44B" {
+		t.Fatalf("member_label.emoji got %v, want \\U0001F44B", req.MemberLabel.Emoji)
+	}
+}

--- a/src/client/client.go
+++ b/src/client/client.go
@@ -113,23 +113,27 @@ func (g GroupLinkState) FromString(input string) GroupLinkState {
 }
 
 type GroupEntry struct {
-	Name            string              `json:"name"`
-	Description     string              `json:"description"`
-	Id              string              `json:"id"`
-	InternalId      string              `json:"internal_id"`
-	Members         []string            `json:"members"`
-	Blocked         bool                `json:"blocked"`
-	Member          bool                `json:"member"`
-	PendingInvites  []string            `json:"pending_invites"`
-	PendingRequests []string            `json:"pending_requests"`
-	InviteLink      string              `json:"invite_link"`
-	Admins          []string            `json:"admins"`
-	Permissions     ds.GroupPermissions `json:"permissions"`
+	Name             string              `json:"name"`
+	Description      string              `json:"description"`
+	Id               string              `json:"id"`
+	InternalId       string              `json:"internal_id"`
+	MemberLabel      string              `json:"member_label"`
+	MemberLabelEmoji string              `json:"member_label_emoji"`
+	Members          []string            `json:"members"`
+	Blocked          bool                `json:"blocked"`
+	Member           bool                `json:"member"`
+	PendingInvites   []string            `json:"pending_invites"`
+	PendingRequests  []string            `json:"pending_requests"`
+	InviteLink       string              `json:"invite_link"`
+	Admins           []string            `json:"admins"`
+	Permissions      ds.GroupPermissions `json:"permissions"`
 }
 
 type GroupMember struct {
-	Number string `json:"number"`
-	Uuid   string `json:"uuid"`
+	Number     string  `json:"number"`
+	Uuid       string  `json:"uuid"`
+	LabelEmoji *string `json:"label_emoji,omitempty"`
+	Label      *string `json:"label,omitempty"`
 }
 
 type GroupAdmin struct {
@@ -137,19 +141,28 @@ type GroupAdmin struct {
 	Uuid   string `json:"uuid"`
 }
 
+type SignalCliGroupMember struct {
+	Number     string  `json:"number"`
+	Uuid       string  `json:"uuid"`
+	LabelEmoji *string `json:"labelEmoji"`
+	Label      *string `json:"label"`
+}
+
 type ExpandedGroupEntry struct {
-	Name            string              `json:"name"`
-	Description     string              `json:"description"`
-	Id              string              `json:"id"`
-	InternalId      string              `json:"internal_id"`
-	Members         []GroupMember       `json:"members"`
-	Blocked         bool                `json:"blocked"`
-	Member          bool                `json:"member"`
-	PendingInvites  []GroupMember       `json:"pending_invites"`
-	PendingRequests []GroupMember       `json:"pending_requests"`
-	InviteLink      string              `json:"invite_link"`
-	Admins          []GroupAdmin        `json:"admins"`
-	Permissions     ds.GroupPermissions `json:"permissions"`
+	Name             string              `json:"name"`
+	Description      string              `json:"description"`
+	Id               string              `json:"id"`
+	InternalId       string              `json:"internal_id"`
+	MemberLabel      string              `json:"member_label"`
+	MemberLabelEmoji string              `json:"member_label_emoji"`
+	Members          []GroupMember       `json:"members"`
+	Blocked          bool                `json:"blocked"`
+	Member           bool                `json:"member"`
+	PendingInvites   []GroupMember       `json:"pending_invites"`
+	PendingRequests  []GroupMember       `json:"pending_requests"`
+	InviteLink       string              `json:"invite_link"`
+	Admins           []GroupAdmin        `json:"admins"`
+	Permissions      ds.GroupPermissions `json:"permissions"`
 }
 
 type IdentityEntry struct {
@@ -162,20 +175,22 @@ type IdentityEntry struct {
 }
 
 type SignalCliGroupEntry struct {
-	Name                  string        `json:"name"`
-	Description           string        `json:"description"`
-	Id                    string        `json:"id"`
-	IsMember              bool          `json:"isMember"`
-	IsBlocked             bool          `json:"isBlocked"`
-	Members               []GroupMember `json:"members"`
-	PendingMembers        []GroupMember `json:"pendingMembers"`
-	RequestingMembers     []GroupMember `json:"requestingMembers"`
-	GroupInviteLink       string        `json:"groupInviteLink"`
-	Admins                []GroupAdmin  `json:"admins"`
-	Uuid                  string        `json:"uuid"`
-	PermissionEditDetails string        `json:"permissionEditDetails"`
-	PermissionAddMember   string        `json:"permissionAddMember"`
-	PermissionSendMessage string        `json:"permissionSendMessage"`
+	Name                  string                 `json:"name"`
+	Description           string                 `json:"description"`
+	Id                    string                 `json:"id"`
+	IsMember              bool                   `json:"isMember"`
+	IsBlocked             bool                   `json:"isBlocked"`
+	MemberLabel           *string                `json:"memberLabel"`
+	MemberLabelEmoji      *string                `json:"memberLabelEmoji"`
+	Members               []SignalCliGroupMember `json:"members"`
+	PendingMembers        []GroupMember          `json:"pendingMembers"`
+	RequestingMembers     []GroupMember          `json:"requestingMembers"`
+	GroupInviteLink       string                 `json:"groupInviteLink"`
+	Admins                []GroupAdmin           `json:"admins"`
+	Uuid                  string                 `json:"uuid"`
+	PermissionEditDetails string                 `json:"permissionEditDetails"`
+	PermissionAddMember   string                 `json:"permissionAddMember"`
+	PermissionSendMessage string                 `json:"permissionSendMessage"`
 }
 
 type SignalCliIdentityEntry struct {
@@ -1207,6 +1222,35 @@ func prefixUsernameMembers(members []string) []string {
 	return res
 }
 
+func signalCliGroupMembersToGroupMembers(signalCliGroupMembers []SignalCliGroupMember) []GroupMember {
+	groupMembers := []GroupMember{}
+	for _, signalCliGroupMember := range signalCliGroupMembers {
+		groupMembers = append(groupMembers, GroupMember{
+			Number:     signalCliGroupMember.Number,
+			Uuid:       signalCliGroupMember.Uuid,
+			LabelEmoji: signalCliGroupMember.LabelEmoji,
+			Label:      signalCliGroupMember.Label,
+		})
+	}
+	return groupMembers
+}
+
+func stringValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func findOwnGroupMemberLabel(members []SignalCliGroupMember, number string) (string, string) {
+	for _, member := range members {
+		if member.Number == number {
+			return stringValue(member.Label), stringValue(member.LabelEmoji)
+		}
+	}
+	return "", ""
+}
+
 func (s *SignalClient) updateGroupMembers(number string, groupId string, members []string, add bool) error {
 
 	if len(members) == 0 {
@@ -1340,10 +1384,12 @@ func signalCliGroupEntryToExpandedGroupEntry(signalCliGroupEntry SignalCliGroupE
 	groupEntry.Blocked = signalCliGroupEntry.IsBlocked
 	groupEntry.Member = signalCliGroupEntry.IsMember
 	groupEntry.Description = signalCliGroupEntry.Description
+	groupEntry.MemberLabel = stringValue(signalCliGroupEntry.MemberLabel)
+	groupEntry.MemberLabelEmoji = stringValue(signalCliGroupEntry.MemberLabelEmoji)
 	groupEntry.Permissions.SendMessages = signalCliGroupPermissionToRestApiGroupPermission(signalCliGroupEntry.PermissionSendMessage)
 	groupEntry.Permissions.EditGroup = signalCliGroupPermissionToRestApiGroupPermission(signalCliGroupEntry.PermissionSendMessage)
 	groupEntry.Permissions.AddMembers = signalCliGroupPermissionToRestApiGroupPermission(signalCliGroupEntry.PermissionAddMember)
-	groupEntry.Members = signalCliGroupEntry.Members
+	groupEntry.Members = signalCliGroupMembersToGroupMembers(signalCliGroupEntry.Members)
 	groupEntry.PendingInvites = signalCliGroupEntry.PendingMembers
 	groupEntry.PendingRequests = signalCliGroupEntry.RequestingMembers
 	groupEntry.Admins = signalCliGroupEntry.Admins
@@ -1381,7 +1427,11 @@ func (s *SignalClient) GetGroupsExpanded(number string) ([]ExpandedGroupEntry, e
 	}
 
 	for _, signalCliGroupEntry := range signalCliGroupEntries {
-		groupEntries = append(groupEntries, signalCliGroupEntryToExpandedGroupEntry(signalCliGroupEntry))
+		groupEntry := signalCliGroupEntryToExpandedGroupEntry(signalCliGroupEntry)
+		if groupEntry.MemberLabel == "" && groupEntry.MemberLabelEmoji == "" {
+			groupEntry.MemberLabel, groupEntry.MemberLabelEmoji = findOwnGroupMemberLabel(signalCliGroupEntry.Members, number)
+		}
+		groupEntries = append(groupEntries, groupEntry)
 	}
 
 	return groupEntries, nil
@@ -1397,6 +1447,7 @@ func (s *SignalClient) GetGroups(number string) ([]GroupEntry, error) {
 	for _, expandedGroupEntry := range expandedGroupEntries {
 		groupEntry := GroupEntry{InternalId: expandedGroupEntry.InternalId, Name: expandedGroupEntry.Name,
 			Id: expandedGroupEntry.Id, Blocked: expandedGroupEntry.Blocked, Member: expandedGroupEntry.Member, Description: expandedGroupEntry.Description,
+			MemberLabel: expandedGroupEntry.MemberLabel, MemberLabelEmoji: expandedGroupEntry.MemberLabelEmoji,
 			Permissions: expandedGroupEntry.Permissions, InviteLink: expandedGroupEntry.InviteLink}
 
 		members := []string{}

--- a/src/client/client.go
+++ b/src/client/client.go
@@ -2059,7 +2059,8 @@ func (s *SignalClient) QuitGroup(number string, groupId string) error {
 }
 
 func (s *SignalClient) UpdateGroup(number string, groupId string, base64Avatar *string, groupDescription *string, groupName *string, expirationTime *int,
-	groupLinkState *GroupLinkState, editGroupPermission GroupPermission, addMembersPermission GroupPermission, sendMessagesPermission GroupPermission) error {
+	groupLinkState *GroupLinkState, editGroupPermission GroupPermission, addMembersPermission GroupPermission, sendMessagesPermission GroupPermission,
+	memberLabel *string, memberLabelEmoji *string) error {
 	var err error
 	var avatarTmpPath string = ""
 	if base64Avatar != nil {
@@ -2108,6 +2109,8 @@ func (s *SignalClient) UpdateGroup(number string, groupId string, base64Avatar *
 			EditGroupPermissions    string  `json:"setPermissionEditDetails,omitempty"`
 			AddMembersPermissions   string  `json:"setPermissionAddMember,omitempty"`
 			SendMessagesPermissions string  `json:"setPermissionSendMessages,omitempty"`
+			MemberLabel             *string `json:"memberLabel,omitempty"`
+			MemberLabelEmoji        *string `json:"memberLabelEmoji,omitempty"`
 		}
 		request := Request{GroupId: groupId}
 
@@ -2137,6 +2140,9 @@ func (s *SignalClient) UpdateGroup(number string, groupId string, base64Avatar *
 		if sendMessagesPermission != DefaultGroupPermission {
 			request.SendMessagesPermissions = sendMessagesPermission.String()
 		}
+
+		request.MemberLabel = memberLabel
+		request.MemberLabelEmoji = memberLabelEmoji
 
 		jsonRpc2Client, err := s.getJsonRpc2Client()
 		if err != nil {
@@ -2175,6 +2181,14 @@ func (s *SignalClient) UpdateGroup(number string, groupId string, base64Avatar *
 
 		if sendMessagesPermission != DefaultGroupPermission {
 			cmd = append(cmd, []string{"--set-permission-send-messages", sendMessagesPermission.String()}...)
+		}
+
+		if memberLabelEmoji != nil {
+			cmd = append(cmd, []string{"--member-label-emoji", *memberLabelEmoji}...)
+		}
+
+		if memberLabel != nil {
+			cmd = append(cmd, []string{"--member-label", *memberLabel}...)
 		}
 
 		_, err = s.cliClient.Execute(true, cmd, "")

--- a/src/client/group_test.go
+++ b/src/client/group_test.go
@@ -1,0 +1,82 @@
+package client
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestSignalCliGroupEntryMemberLabelFields(t *testing.T) {
+	var signalCliGroupEntry SignalCliGroupEntry
+	rawGroup := []byte(`{"id":"abc","members":[{"number":"+1234","uuid":"uuid-1","labelEmoji":"\ud83d\udc4b","label":"Dad"}]}`)
+
+	if err := json.Unmarshal(rawGroup, &signalCliGroupEntry); err != nil {
+		t.Fatalf("json.Unmarshal() error: %v", err)
+	}
+
+	memberLabel, memberLabelEmoji := findOwnGroupMemberLabel(signalCliGroupEntry.Members, "+1234")
+
+	if memberLabel != "Dad" {
+		t.Fatalf("memberLabel got %v, want Dad", memberLabel)
+	}
+
+	if memberLabelEmoji != "\U0001F44B" {
+		t.Fatalf("memberLabelEmoji got %v, want \\U0001F44B", memberLabelEmoji)
+	}
+
+	groupEntry := GroupEntry{
+		MemberLabel:      memberLabel,
+		MemberLabelEmoji: memberLabelEmoji,
+	}
+
+	encodedGroup, err := json.Marshal(groupEntry)
+	if err != nil {
+		t.Fatalf("json.Marshal() error: %v", err)
+	}
+
+	var response map[string]any
+	if err := json.Unmarshal(encodedGroup, &response); err != nil {
+		t.Fatalf("json.Unmarshal() response error: %v", err)
+	}
+
+	if response["member_label"] != "Dad" {
+		t.Fatalf("member_label got %v, want Dad", response["member_label"])
+	}
+
+	if response["member_label_emoji"] != "\U0001F44B" {
+		t.Fatalf("member_label_emoji got %v, want \\U0001F44B", response["member_label_emoji"])
+	}
+}
+
+func TestSignalCliGroupEntryMissingMemberLabelFields(t *testing.T) {
+	var signalCliGroupEntry SignalCliGroupEntry
+	rawGroup := []byte(`{"id":"abc","members":[{"number":"+1234","uuid":"uuid-1"}]}`)
+
+	if err := json.Unmarshal(rawGroup, &signalCliGroupEntry); err != nil {
+		t.Fatalf("json.Unmarshal() error: %v", err)
+	}
+
+	memberLabel, memberLabelEmoji := findOwnGroupMemberLabel(signalCliGroupEntry.Members, "+1234")
+
+	groupEntry := GroupEntry{
+		MemberLabel:      memberLabel,
+		MemberLabelEmoji: memberLabelEmoji,
+	}
+
+	encodedGroup, err := json.Marshal(groupEntry)
+	if err != nil {
+		t.Fatalf("json.Marshal() error: %v", err)
+	}
+
+	var response map[string]any
+	if err := json.Unmarshal(encodedGroup, &response); err != nil {
+		t.Fatalf("json.Unmarshal() response error: %v", err)
+	}
+
+	if response["member_label"] != "" {
+		t.Fatalf("member_label got %v, want empty string", response["member_label"])
+	}
+
+	if response["member_label_emoji"] != "" {
+		t.Fatalf("member_label_emoji got %v, want empty string", response["member_label_emoji"])
+	}
+}

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -654,6 +654,12 @@ const docTemplate = `{
                     ],
                     "type": "string"
                 },
+                "member_label": {
+                    "type": "string"
+                },
+                "member_label_emoji": {
+                    "type": "string"
+                },
                 "name": {
                     "type": "string"
                 },

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -815,6 +815,12 @@ const docTemplate = `{
                 "member": {
                     "type": "boolean"
                 },
+                "member_label": {
+                    "type": "string"
+                },
+                "member_label_emoji": {
+                    "type": "string"
+                },
                 "members": {
                     "items": {
                         "type": "string"
@@ -848,6 +854,8 @@ const docTemplate = `{
                 "internal_id",
                 "invite_link",
                 "member",
+                "member_label",
+                "member_label_emoji",
                 "members",
                 "name",
                 "pending_invites",

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -219,6 +219,17 @@ const docTemplate = `{
             ],
             "type": "object"
         },
+        "api.MemberLabel": {
+            "properties": {
+                "emoji": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "api.PinMessageInGroupRequest": {
             "properties": {
                 "duration": {
@@ -655,10 +666,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "member_label": {
-                    "type": "string"
-                },
-                "member_label_emoji": {
-                    "type": "string"
+                    "$ref": "#/definitions/api.MemberLabel"
                 },
                 "name": {
                     "type": "string"

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -810,6 +810,12 @@
                 "member": {
                     "type": "boolean"
                 },
+                "member_label": {
+                    "type": "string"
+                },
+                "member_label_emoji": {
+                    "type": "string"
+                },
                 "members": {
                     "items": {
                         "type": "string"
@@ -843,6 +849,8 @@
                 "internal_id",
                 "invite_link",
                 "member",
+                "member_label",
+                "member_label_emoji",
                 "members",
                 "name",
                 "pending_invites",

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -649,6 +649,12 @@
                     ],
                     "type": "string"
                 },
+                "member_label": {
+                    "type": "string"
+                },
+                "member_label_emoji": {
+                    "type": "string"
+                },
                 "name": {
                     "type": "string"
                 },

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -214,6 +214,17 @@
             ],
             "type": "object"
         },
+        "api.MemberLabel": {
+            "properties": {
+                "emoji": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "api.PinMessageInGroupRequest": {
             "properties": {
                 "duration": {
@@ -650,10 +661,7 @@
                     "type": "string"
                 },
                 "member_label": {
-                    "type": "string"
-                },
-                "member_label_emoji": {
-                    "type": "string"
+                    "$ref": "#/definitions/api.MemberLabel"
                 },
                 "name": {
                     "type": "string"


### PR DESCRIPTION
I had a use-case for the new label (and emoji) feature in groups, and noted that `signal-cli` had support (https://github.com/AsamK/signal-cli/commit/27a722dc757eba633f9014738efa0f1c3f722f28) but not `signal-cli-rest-api`. 

If unaware of this functionality, it allows you to set a label for yourself in a group that's then visible for others:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/a3e9a0e8-335d-4dc8-82c5-42a2747b0aff" />

This PR has three commits;

[f07c587](https://github.com/bbernhard/signal-cli-rest-api/pull/850/commits/f07c5873099c7d904313c2fc6768d7dcb0bff89e) adds support for setting the label via `PUT` `/v1/groups/<number>/<group id>` with `member_label` and `member_label_emoji`.

[0938262](https://github.com/bbernhard/signal-cli-rest-api/pull/850/commits/0938262814a70af91f7daba84e868586c1c6bc4a) exposes the labels set in various groups on `GET` `/v1/groups/<number>`.

[fc9a90c](https://github.com/bbernhard/signal-cli-rest-api/pull/850/commits/fc9a90cb7704e3729a966730ebc6eb018c9d3b37) updates the public request interface based on review feedback, using the nested structure `{"member_label": {"name": "<label>", "emoji": "<emoji>"}}`.