### PR TITLE
feat: add receive schemas to check-docks worflow

### DIFF
--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -23,6 +23,15 @@ jobs:
         working-directory: src
         run: go run github.com/swaggo/swag/cmd/swag@v1.16.6 init --requiredByDefault
 
+      - name: Download and inject receive schemas
+        working-directory: src/docs
+        run: |
+          SIGNAL_CLI_VERSION="$(grep -m1 '^ARG SIGNAL_CLI_VERSION=' ../../Dockerfile | cut -d= -f2)"
+          curl -fsSL "https://github.com/Gara-Dorta/signal-cli/releases/download/v${SIGNAL_CLI_VERSION}/signal-cli-${SIGNAL_CLI_VERSION}-json-schemas.tar.gz" -o signal-cli-json-schemas.tar.gz
+          mkdir -p signal-cli-schemas
+          tar xf signal-cli-json-schemas.tar.gz -C signal-cli-schemas
+          go run add_v1_receive_schemas.go signal-cli-schemas
+
       - name: Fail if docs are out of date
         run: |
           git diff --exit-code -- src/docs/docs.go src/docs/swagger.json src/docs/swagger.yaml


### PR DESCRIPTION
This PR adds the receive schemas to the check-docs.yml workflow. Here is a successful run of it https://github.com/Gara-Dorta/signal-cli-rest-api/actions/runs/26340800873

This is a follow up of #849 and #842, they got merged at the same time but they have this interaction with each other.