### PR TITLE
fix: prevent slice out of range when attachment data starts with base64,

### DIFF
--- a/src/client/attachment.go
+++ b/src/client/attachment.go
@@ -44,6 +44,9 @@ func (attachmentEntry *AttachmentEntry) extractMetaData(attachmentData string) {
 	}
 
 	attachmentEntry.Base64 = attachmentData[base64FlagIndex+len("base64,"):]
+	if base64FlagIndex == 0 {
+		return
+	}
 	metaDataKeys := map[string]string{
 		"data:":     "MimeInfo",
 		"filename=": "FileName",

--- a/src/client/attachment_test.go
+++ b/src/client/attachment_test.go
@@ -45,6 +45,9 @@ func Test_Attachment_ExtractMetadata_ShouldPrepareDataFor_toDataForSignal(t *tes
 		{
 			"-base64 +data +filename", "data:someData;filename=file.name;INVALIDMTIzNDU=", false, "data:someData;filename=file.name;INVALIDMTIzNDU=", false, "", "", "data:someData;filename=file.name;INVALIDMTIzNDU=",
 		},
+		{
+			"base64 prefix at start +data", "base64,data:someData", false, "data:someData", false, "", "", "data:someData",
+		},
 	}
 
 	attachmentTmp := flag.String("attachment-tmp-dir", string(os.PathSeparator)+"tmp"+string(os.PathSeparator), "Attachment tmp directory")


### PR DESCRIPTION
`extractMetaData` computes `base64FlagIndex` via `strings.LastIndex(attachmentData, "base64,")` and then slices `attachmentData[:base64FlagIndex-1]`. When the attachment data starts with `base64,` (index 0) and also contains `data:`, that becomes `attachmentData[:-1]` and panics with `slice bounds out of range [:-1]`.

The attachment string comes from request payloads, so a crafted value such as `base64,data:x` crashes the request goroutine.

Fix: when `base64FlagIndex == 0` there is no metadata prefix to parse, so return after setting Base64. Added a table case covering the crashing input.