### PR TITLE
Add voice_note parameter to the send endpoint

### DIFF
--- a/src/api/api.go
+++ b/src/api/api.go
@@ -142,6 +142,7 @@ type SendMessageV2 struct {
 	NotifySelf        *bool               `json:"notify_self,omitempty"`
 	LinkPreview       *ds.LinkPreviewType `json:"link_preview,omitempty"`
 	ViewOnce          *bool               `json:"view_once,omitempty"`
+	VoiceNote         *bool               `json:"voice_note,omitempty"`
 }
 
 type TypingIndicatorRequest struct {
@@ -546,10 +547,15 @@ func (a *Api) SendV2(c *gin.Context) {
 		return
 	}
 
+	if req.VoiceNote != nil && *req.VoiceNote && (len(req.Base64Attachments) == 0) {
+		c.JSON(400, Error{Msg: "'voice_note' can only be set for audio attachments!"})
+		return
+	}
+
 	data, err := a.signalClient.SendV2(
 		req.Number, req.Message, req.Recipients, req.Base64Attachments, req.Sticker,
 		req.Mentions, req.QuoteTimestamp, req.QuoteAuthor, req.QuoteMessage, req.QuoteMentions,
-		textMode, req.EditTimestamp, req.NotifySelf, req.LinkPreview, req.ViewOnce)
+		textMode, req.EditTimestamp, req.NotifySelf, req.LinkPreview, req.ViewOnce, req.VoiceNote)
 	if err != nil {
 		switch err.(type) {
 		case *client.RateLimitErrorType:

--- a/src/client/client.go
+++ b/src/client/client.go
@@ -550,6 +550,7 @@ func (s *SignalClient) send(signalCliSendRequest ds.SignalCliSendRequest) (*ds.S
 			PreviewImage       *string  `json:"preview-image,omitempty"`
 			PreviewDescription *string  `json:"preview-description,omitempty"`
 			ViewOnce           bool     `json:"view-once,omitempty"`
+			VoiceNote          bool     `json:"voice-note,omitempty"`
 		}
 
 		request := Request{Message: signalCliSendRequest.Message}
@@ -571,6 +572,10 @@ func (s *SignalClient) send(signalCliSendRequest ds.SignalCliSendRequest) (*ds.S
 
 		if signalCliSendRequest.ViewOnce != nil && *signalCliSendRequest.ViewOnce {
 			request.ViewOnce = true
+		}
+
+		if signalCliSendRequest.VoiceNote != nil && *signalCliSendRequest.VoiceNote {
+			request.VoiceNote = true
 		}
 
 		request.Sticker = signalCliSendRequest.Sticker
@@ -707,6 +712,10 @@ func (s *SignalClient) send(signalCliSendRequest ds.SignalCliSendRequest) (*ds.S
 
 		if signalCliSendRequest.ViewOnce != nil && *signalCliSendRequest.ViewOnce {
 			cmd = append(cmd, "--view-once")
+		}
+
+		if signalCliSendRequest.VoiceNote != nil && *signalCliSendRequest.VoiceNote {
+			cmd = append(cmd, "--voice-note")
 		}
 
 		rawData, err = s.cliClient.Execute(true, cmd, signalCliSendRequest.Message)
@@ -946,7 +955,7 @@ func (s *SignalClient) getJsonRpc2Clients() []*JsonRpc2Client {
 
 func (s *SignalClient) SendV2(number string, message string, recps []string, base64Attachments []string, sticker string, mentions []ds.MessageMention,
 	quoteTimestamp *int64, quoteAuthor *string, quoteMessage *string, quoteMentions []ds.MessageMention, textMode *string, editTimestamp *int64, notifySelf *bool,
-	linkPreview *ds.LinkPreviewType, viewOnce *bool) (*[]ds.SendMessageResponse, error) {
+	linkPreview *ds.LinkPreviewType, viewOnce *bool, voiceNote *bool) (*[]ds.SendMessageResponse, error) {
 	if len(recps) == 0 {
 		return nil, errors.New("Please provide at least one recipient")
 	}
@@ -997,7 +1006,7 @@ func (s *SignalClient) SendV2(number string, message string, recps []string, bas
 		signalCliSendRequest := ds.SignalCliSendRequest{Number: number, Message: message, Recipients: []string{group}, Base64Attachments: base64Attachments,
 			RecipientType: ds.Group, Sticker: sticker, Mentions: mentions, QuoteTimestamp: quoteTimestamp,
 			QuoteAuthor: quoteAuthor, QuoteMessage: quoteMessage, QuoteMentions: quoteMentions,
-			TextMode: textMode, EditTimestamp: editTimestamp, NotifySelf: notifySelf, LinkPreview: linkPreview, ViewOnce: viewOnce}
+			TextMode: textMode, EditTimestamp: editTimestamp, NotifySelf: notifySelf, LinkPreview: linkPreview, ViewOnce: viewOnce, VoiceNote: voiceNote}
 		resp, err := s.send(signalCliSendRequest)
 		if err != nil {
 			return nil, err
@@ -1009,7 +1018,7 @@ func (s *SignalClient) SendV2(number string, message string, recps []string, bas
 		signalCliSendRequest := ds.SignalCliSendRequest{Number: number, Message: message, Recipients: numbers, Base64Attachments: base64Attachments,
 			RecipientType: ds.Number, Sticker: sticker, Mentions: mentions, QuoteTimestamp: quoteTimestamp,
 			QuoteAuthor: quoteAuthor, QuoteMessage: quoteMessage, QuoteMentions: quoteMentions,
-			TextMode: textMode, EditTimestamp: editTimestamp, NotifySelf: notifySelf, LinkPreview: linkPreview, ViewOnce: viewOnce}
+			TextMode: textMode, EditTimestamp: editTimestamp, NotifySelf: notifySelf, LinkPreview: linkPreview, ViewOnce: viewOnce, VoiceNote: voiceNote}
 		resp, err := s.send(signalCliSendRequest)
 		if err != nil {
 			return nil, err
@@ -1021,7 +1030,7 @@ func (s *SignalClient) SendV2(number string, message string, recps []string, bas
 		signalCliSendRequest := ds.SignalCliSendRequest{Number: number, Message: message, Recipients: usernames, Base64Attachments: base64Attachments,
 			RecipientType: ds.Username, Sticker: sticker, Mentions: mentions, QuoteTimestamp: quoteTimestamp,
 			QuoteAuthor: quoteAuthor, QuoteMessage: quoteMessage, QuoteMentions: quoteMentions,
-			TextMode: textMode, EditTimestamp: editTimestamp, NotifySelf: notifySelf, LinkPreview: linkPreview, ViewOnce: viewOnce}
+			TextMode: textMode, EditTimestamp: editTimestamp, NotifySelf: notifySelf, LinkPreview: linkPreview, ViewOnce: viewOnce, VoiceNote: voiceNote}
 		resp, err := s.send(signalCliSendRequest)
 		if err != nil {
 			return nil, err

--- a/src/datastructs/datastructs.go
+++ b/src/datastructs/datastructs.go
@@ -51,6 +51,7 @@ type SignalCliSendRequest struct {
 	NotifySelf        *bool
 	LinkPreview       *LinkPreviewType
 	ViewOnce          *bool
+	VoiceNote         *bool
 }
 
 type GroupPermissions struct {

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -468,6 +468,9 @@ const docTemplate = `{
                 },
                 "view_once": {
                     "type": "boolean"
+                },
+                "voice_note": {
+                    "type": "boolean"
                 }
             },
             "required": [

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -463,6 +463,9 @@
                 },
                 "view_once": {
                     "type": "boolean"
+                },
+                "voice_note": {
+                    "type": "boolean"
                 }
             },
             "required": [


### PR DESCRIPTION
## What

Adds an optional `voice_note` boolean to `POST /v2/send`, exposing signal-cli's existing `--voice-note` flag.

## Why

signal-cli can mark audio attachments as voice notes, which makes Signal clients render them inline with a waveform and playback scrubber. The REST API had no way to set it, so audio sent through `base64_attachments` always arrives as a generic file attachment.

## How

The plumbing mirrors the existing `view_once` parameter:

- `voice_note` on `SendMessageV2` → `SignalCliSendRequest.VoiceNote`
- json-rpc mode: adds `"voice-note": true` to the `send` request
- native mode: appends `--voice-note` to the signal-cli invocation
- returns `400` if `voice_note` is set without any attachment, matching the `view_once` behaviour

## Testing

- `go build ./...` and `go test ./client ./utils` pass
- Verified in json-rpc mode by capturing the JSON-RPC frames sent to signal-cli: two otherwise identical requests differ only by the presence of `"voice-note": true`, and the flag is absent when the parameter is omitted
- Confirmed end to end against a real account: an AAC attachment sent with `voice_note: true` is delivered as an inline voice note

## Note on the generated docs

`src/docs/docs.go` and `src/docs/swagger.json` were updated by hand (a single `voice_note` property on `api.SendMessageV2`) rather than by re-running `swag init`. A plain regeneration drops the 42 injected `receive.*` definitions added by `add_v1_receive_schemas.go` and reorders the whole document, which would have buried the change. Happy to regenerate properly if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
